### PR TITLE
add cumulative capacity to summary stats

### DIFF
--- a/beep/structure.py
+++ b/beep/structure.py
@@ -240,12 +240,14 @@ class RawCyclerRun(MSONable):
         data = data.sort_index()
         return cls(data, d['metadata'], d['eis'])
 
-    def get_summary(self, nominal_capacity=1.1, full_fast_charge=0.8,
-                    cycle_complete_discharge_ratio=0.97, cycle_complete_vmin=3.3, cycle_complete_vmax=3.3):
+    def get_summary(self, diagnostic_available=None, nominal_capacity=1.1,
+                    full_fast_charge=0.8, cycle_complete_discharge_ratio=0.97,
+                    cycle_complete_vmin=3.3, cycle_complete_vmax=3.3):
         """
         Gets summary statistics for data according to
 
         Args:
+            diagnostic_available (dict): dictionary with diagnostic_types
             nominal_capacity (float): nominal capacity for summary stats
             full_fast_charge (float): full fast charge for summary stats
             cycle_complete_discharge_ratio (float): expected ratio
@@ -259,6 +261,16 @@ class RawCyclerRun(MSONable):
             pandas.DataFrame: summary statistics by cycle.
 
         """
+        #Filter out only regular cycles for summary stats. Diagnostic summary computed separately
+        if diagnostic_available:
+            diag_cycles = list(itertools.chain.from_iterable(
+                [list(range(i, i + diagnostic_available['length'])) for i in
+                 diagnostic_available['diagnostic_starts_at']
+                 if i <= self.data.cycle_index.max()]))
+            reg_cycles_at = [i for i in self.data.cycle_index.unique() if i not in diag_cycles]
+        else:
+            reg_cycles_at = [i for i in self.data.cycle_index.unique()]
+
         summary = self.data.groupby("cycle_index").agg({
             "discharge_capacity": "max",
             "charge_capacity": "max",
@@ -273,9 +285,11 @@ class RawCyclerRun(MSONable):
                            'dc_internal_resistance', 'temperature_maximum',
                            'temperature_average', 'temperature_minimum',
                            'date_time_iso']
-
+        summary = summary[summary.index.isin(reg_cycles_at)]
         summary['energy_efficiency'] = summary['discharge_energy']/summary['charge_energy']
         summary.loc[~np.isfinite(summary['energy_efficiency']), 'energy_efficiency'] = np.NaN
+        summary['charge_throughput'] = summary.charge_capacity.cumsum()
+        summary['energy_throughput'] = summary.charge_energy.cumsum()
 
         # This method for computing charge start and end times implicitly
         # assumes that a cycle starts with a charge step and is then followed

--- a/beep/tests/test_structure.py
+++ b/beep/tests/test_structure.py
@@ -252,7 +252,8 @@ class RawCyclerRunTest(unittest.TestCase):
         summary = cycler_run.get_summary(nominal_capacity=4.7, full_fast_charge=0.8)
         self.assertTrue(set.issubset({'discharge_capacity', 'charge_capacity', 'dc_internal_resistance',
                                       'temperature_maximum', 'temperature_average', 'temperature_minimum',
-                                      'date_time_iso'}, set(summary.columns)))
+                                      'date_time_iso', 'charge_throughput', 'energy_throughput',
+                                      'charge_energy', 'discharge_energy', 'energy_efficiency'}, set(summary.columns)))
         self.assertEqual(len(summary.index), len(summary['date_time_iso']))
 
     def test_get_energy(self):
@@ -260,6 +261,12 @@ class RawCyclerRunTest(unittest.TestCase):
         summary = cycler_run.get_summary(nominal_capacity=4.7, full_fast_charge=0.8)
         self.assertEqual(summary['charge_energy'][5], 3.7134638)
         self.assertEqual(summary['energy_efficiency'][5], 0.872866405753033)
+
+    def test_get_charge_throughput(self):
+        cycler_run = RawCyclerRun.from_file(self.arbin_file)
+        summary = cycler_run.get_summary(nominal_capacity=4.7, full_fast_charge=0.8)
+        self.assertEqual(summary['charge_throughput'][5], 6.7614094)
+        self.assertEqual(summary['energy_throughput'][5], 23.2752363)
 
     def test_ingestion_indigo(self):
 
@@ -379,7 +386,6 @@ class CliTest(unittest.TestCase):
         with ScratchDir('.'):
             # Set root env
             os.environ['BEEP_ROOT'] = os.getcwd()
-
             # Make necessary directories
             os.mkdir("data-share")
             os.mkdir(os.path.join("data-share", "structure"))


### PR DESCRIPTION
PR to 
- add cumulative charge capacity and charge energy as columns to the summary dataframe
- exclude diagnostic cycles from regular summary calc.