### PR TITLE
Mat 1542 change assertion to error log

### DIFF
--- a/beep/structure.py
+++ b/beep/structure.py
@@ -1313,7 +1313,8 @@ def get_protocol_parameters(filepath, parameters_path='data-share/raw/parameters
     if len(project_parameter_files) == 1:
         df = pd.read_csv(project_parameter_files[0])
         parameter_row = df[df.seq_num == int(project_name_list[1])]
-        assert parameter_row.empty is False, "Unable to get project parameters for: " + filepath
+        if parameter_row.empty is not False:
+            logger.error("Unable to get project parameters for: %s", filepath, extra=s)
     else:
         parameter_row = None
         df = None

--- a/beep/structure.py
+++ b/beep/structure.py
@@ -1313,8 +1313,10 @@ def get_protocol_parameters(filepath, parameters_path='data-share/raw/parameters
     if len(project_parameter_files) == 1:
         df = pd.read_csv(project_parameter_files[0])
         parameter_row = df[df.seq_num == int(project_name_list[1])]
-        if parameter_row.empty is not False:
+        if parameter_row.empty:
             logger.error("Unable to get project parameters for: %s", filepath, extra=s)
+            parameter_row = None
+            df = None
     else:
         parameter_row = None
         df = None

--- a/beep/tests/test_structure.py
+++ b/beep/tests/test_structure.py
@@ -332,6 +332,10 @@ class RawCyclerRunTest(unittest.TestCase):
         self.assertEqual(parameters_missing, None)
         self.assertEqual(project_missing, None)
 
+        filepath = os.path.join(TEST_FILE_DIR, "PreDiag_000292_tztest.010")
+        parameters, _ = get_protocol_parameters(filepath, parameters_path=test_path)
+        self.assertIsNone(parameters)
+
     def test_determine_structering_parameters(self):
         os.environ['BEEP_ROOT'] = TEST_FILE_DIR
         raw_cycler_run = RawCyclerRun.from_file(self.maccor_file_timestamp)


### PR DESCRIPTION
This PR addresses the assertion error and changes it to a soft error that gets logged. The purpose is to allow processing to proceed even if there is no parameter data for that particular file.