### PR TITLE
Update the rest to increment by 12 min per protocol

### DIFF
--- a/beep/generate_protocol.py
+++ b/beep/generate_protocol.py
@@ -585,7 +585,7 @@ class ProcedureFile:
         """
         steps = proc_dict['MaccorTestProcedure']['ProcSteps']['TestStep']
         # Initial rest
-        offset_seconds = 120
+        offset_seconds = 720
         assert steps[rest_idx]['StepType'] == "Rest"
         assert steps[rest_idx]['Ends']['EndEntry'][0]['EndType'] == "StepTime"
         time_s = int(round(3 * 3600 + offset_seconds * (index % 96)))


### PR DESCRIPTION
This PR is attempting to address a recurring problem where data acquisition stops when the HPPC cycles are running due to a data overload. Increasing the offset to 12 min per protocol should mean ~6 cells are going through the HPPC cycle at a time.