### PR TITLE
Increase the resolution of diagnostic interpolation from 500 to 1000

### DIFF
--- a/beep/structure.py
+++ b/beep/structure.py
@@ -842,7 +842,7 @@ class ProcessedCyclerRun(MSONable):
 
     @classmethod
     def from_raw_cycler_run(cls, raw_cycler_run, v_range=None, resolution=1000,
-                            diagnostic_resolution=500, nominal_capacity=1.1,
+                            diagnostic_resolution=1000, nominal_capacity=1.1,
                             full_fast_charge=0.8, diagnostic_available=False):
         """
         Method to invoke ProcessedCyclerRun from RawCyclerRun object

--- a/beep/structure.py
+++ b/beep/structure.py
@@ -446,8 +446,12 @@ class RawCyclerRun(MSONable):
 
         all_dfs = []
         for (cycle_index, step_index, step_index_counter), df in tqdm(group):
-            new_df = get_interpolated_data(df, field_name="voltage", field_range=v_range,
-                                           columns=incl_columns, resolution=resolution)
+            if diag_dict[cycle_index].index(step_index) == 'hppc':
+                new_df = get_interpolated_data(df, field_name="voltage", field_range=v_range,
+                                               columns=incl_columns, resolution=resolution * 2)
+            else:
+                new_df = get_interpolated_data(df, field_name="voltage", field_range=v_range,
+                                               columns=incl_columns, resolution=resolution)
 
             #Convert interpolated time in seconds back to datetime
             new_df['date_time_iso'] = [datetime.utcfromtimestamp(t).isoformat()
@@ -842,7 +846,7 @@ class ProcessedCyclerRun(MSONable):
 
     @classmethod
     def from_raw_cycler_run(cls, raw_cycler_run, v_range=None, resolution=1000,
-                            diagnostic_resolution=1000, nominal_capacity=1.1,
+                            diagnostic_resolution=500, nominal_capacity=1.1,
                             full_fast_charge=0.8, diagnostic_available=False):
         """
         Method to invoke ProcessedCyclerRun from RawCyclerRun object

--- a/beep/tests/test_structure.py
+++ b/beep/tests/test_structure.py
@@ -188,7 +188,7 @@ class RawCyclerRunTest(unittest.TestCase):
                                                             'reset', 'hppc', 'rpt_0.2C', 'rpt_1C', 'rpt_2C',
                                                             'reset', 'hppc'
                                                             ])
-        diag_interpolated = cycler_run.get_interpolated_diagnostic_cycles(diagnostic_available, resolution=500)
+        diag_interpolated = cycler_run.get_interpolated_diagnostic_cycles(diagnostic_available, resolution=1000)
         diag_cycle = diag_interpolated[(diag_interpolated.cycle_type == 'rpt_0.2C')
                                        & (diag_interpolated.step_type == 1)]
         self.assertEqual(diag_cycle.cycle_index.unique().tolist(), [3, 38, 143])
@@ -199,7 +199,7 @@ class RawCyclerRunTest(unittest.TestCase):
         plt.plot(diag_cycle.voltage, diag_cycle.discharge_dQdV)
         plt.savefig(os.path.join(TEST_FILE_DIR, "discharge_dQdV_interpolation.png"))
 
-        self.assertEqual(len(diag_cycle.index), 1500)
+        self.assertEqual(len(diag_cycle.index), 3000)
 
         processed_cycler_run = cycler_run.to_processed_cycler_run()
         self.assertNotIn(diag_summary.index.tolist(), processed_cycler_run.cycles_interpolated.cycle_index.unique())


### PR DESCRIPTION
This PR doubles the resolution of the diagnostic interpolation to address issues in fitting the response of the battery to pulses. This could potentially also create problems in the pipeline due to memory issues.