### PR TITLE
MAT-1603 Reduce memory and reduce warnings

### DIFF
--- a/beep/structure.py
+++ b/beep/structure.py
@@ -164,6 +164,7 @@ class RawCyclerRun(MSONable):
         cycle_indices = [c for c in cycle_indices if c in reg_cycles]
         cycle_indices.sort()
         for cycle_index in tqdm(cycle_indices):
+            # Use a cycle_index mask instead of a global groupby to save memory
             new_df = self.data.loc[self.data["cycle_index"] == cycle_index].groupby("step_index").filter(step_filter)
             if new_df.size == 0:
                 continue


### PR DESCRIPTION
Memory use is decreased, according to memory-profiler. Would appreciate confirmation that these new commands are equivalent to the previous version. Also added some .loc calls to get rid of pandas warning related to "Returning a view vs a copy" (https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-view-versus-copy).

[mem_profile_before.txt](https://github.com/TRI-AMDD/beep/files/4453146/mem_profile_before.txt)
[mem_profile_after.txt](https://github.com/TRI-AMDD/beep/files/4453148/mem_profile_after.txt)

