### PR TITLE
Change the paused column in the summary data to be int type

### DIFF
--- a/beep/structure.py
+++ b/beep/structure.py
@@ -249,7 +249,8 @@ class RawCyclerRun(MSONable):
                     full_fast_charge=0.8, cycle_complete_discharge_ratio=0.97,
                     cycle_complete_vmin=3.3, cycle_complete_vmax=3.3):
         """
-        Gets summary statistics for data according to
+        Gets summary statistics for data according to cycle number. Summary data
+        must be float or int type for compatibility with other methods
 
         Args:
             diagnostic_available (dict): dictionary with diagnostic_types
@@ -1443,7 +1444,7 @@ def determine_paused(group, paused_threshold=3600):
                        if t is not pd.NaT else float('nan')
                        for t in date_time_obj]
     date_time_float = pd.Series(date_time_float)
-    return date_time_float.diff().max() > paused_threshold
+    return int(date_time_float.diff().max() > paused_threshold)
 
 
 def maccor_timestamp(x):

--- a/beep/tests/test_structure.py
+++ b/beep/tests/test_structure.py
@@ -191,6 +191,7 @@ class RawCyclerRunTest(unittest.TestCase):
                                                             'reset', 'hppc', 'rpt_0.2C', 'rpt_1C', 'rpt_2C',
                                                             'reset', 'hppc'
                                                             ])
+        self.assertEqual(diag_summary.paused.max(), 0)
         diag_interpolated = cycler_run.get_interpolated_diagnostic_cycles(diagnostic_available, resolution=1000)
         diag_cycle = diag_interpolated[(diag_interpolated.cycle_type == 'rpt_0.2C')
                                        & (diag_interpolated.step_type == 1)]

--- a/beep/tests/test_structure.py
+++ b/beep/tests/test_structure.py
@@ -273,8 +273,9 @@ class RawCyclerRunTest(unittest.TestCase):
                                       'temperature_maximum', 'temperature_average', 'temperature_minimum',
                                       'date_time_iso', 'charge_throughput', 'energy_throughput',
                                       'charge_energy', 'discharge_energy', 'energy_efficiency'}, set(summary.columns)))
+        self.assertEqual(summary['cycle_index'].tolist(), list(range(0, 13)))
         self.assertEqual(len(summary.index), len(summary['date_time_iso']))
-        self.assertFalse(summary['paused'].any())
+        self.assertEqual(summary['paused'].max(), 0)
 
     def test_get_energy(self):
         cycler_run = RawCyclerRun.from_file(self.arbin_file)
@@ -425,13 +426,12 @@ class RawCyclerRunTest(unittest.TestCase):
                                 'diagnostic_starts_at': [1]
                                 }
         diag_summary = cycler_run.get_diagnostic_summary(diagnostic_available)
-        self.assertFalse(diag_summary['paused'].any())
-
+        self.assertEqual(diag_summary['paused'].max(), 0)
 
     def test_determine_paused(self):
         cycler_run = RawCyclerRun.from_file(self.maccor_file_paused)
         paused = cycler_run.data.groupby('cycle_index').apply(determine_paused)
-        self.assertTrue(paused.any())
+        self.assertEqual(paused.max(), 1)
 
 
 class CliTest(unittest.TestCase):


### PR DESCRIPTION
This PR changes the paused column to be an int value instead of a boolean. Following convention, 0 is False and 1 is True. This change is necessary to prevent errors in the data syncer and the UI