### PR TITLE
MAT-1637: Capitalize Protocol Generator Service Name

### DIFF
--- a/beep/generate_protocol.py
+++ b/beep/generate_protocol.py
@@ -1061,7 +1061,7 @@ def process_csv_file_list_from_json(file_list_json, processed_dir='data-share/pr
         file_list_data = json.loads(file_list_json)
 
     # Setup Events
-    events = KinesisEvents(service='protocolGenerator', mode=file_list_data['mode'])
+    events = KinesisEvents(service='ProtocolGenerator', mode=file_list_data['mode'])
 
     file_list = file_list_data['file_list']
     all_output_files = []


### PR DESCRIPTION
This PR capitalizes the protocol generator event service name so that events are appropriately handled by consuming services.