### PR TITLE
Cast data types for all data frames in the structure

### DIFF
--- a/beep/config.py
+++ b/beep/config.py
@@ -12,7 +12,7 @@ config = {
             'streams': ['CloudWatch']
         },
         'kinesis': {
-            'stream': 'stage/beep/eventstream/stage'
+            'stream': 'local/beep/eventstream'
         }
     },
 

--- a/beep/conversion_schemas/__init__.py
+++ b/beep/conversion_schemas/__init__.py
@@ -13,4 +13,6 @@ xTesladiag_CONFIG = loadfn(os.path.join(CONVERSION_SCHEMA_DIR, "xTESLADIAG_conve
 INDIGO_CONFIG = loadfn(os.path.join(CONVERSION_SCHEMA_DIR, "indigo_conversion.yaml"))
 BIOLOGIC_CONFIG = loadfn(os.path.join(CONVERSION_SCHEMA_DIR, "biologic_conversion.yaml"))
 
+STRUCTURE_DTYPES = loadfn(os.path.join(CONVERSION_SCHEMA_DIR, "structured_dtypes.yaml"))
+
 ALL_CONFIGS = [ARBIN_CONFIG, MACCOR_CONFIG]

--- a/beep/conversion_schemas/structured_dtypes.yaml
+++ b/beep/conversion_schemas/structured_dtypes.yaml
@@ -1,0 +1,65 @@
+cycles_interpolated:
+  cycle_index: 'int32'
+  current: 'float32'
+  voltage: 'float32'
+  temperature: 'float32'
+  internal_resistance: 'float32'
+  charge_capacity: 'float64'
+  discharge_capacity: 'float64'
+  step_type: 'category'
+
+summary:
+  cycle_index: 'int32'
+  discharge_capacity: 'float64'
+  charge_capacity: 'float64'
+  discharge_energy: 'float64'
+  charge_energy: 'float64'
+  dc_internal_resistance: 'float32'
+  temperature_maximum: 'float32'
+  temperature_average: 'float32'
+  temperature_minimum: 'float32'
+  date_time_iso: 'object'
+  energy_efficiency: 'float64'
+  charge_throughput: 'float32'
+  energy_throughput: 'float32'
+  charge_duration: 'float32'
+  time_temperature_integrated: 'float64'
+  paused: 'int8'
+
+diagnostic_summary:
+  discharge_capacity: 'float64'
+  charge_capacity: 'float64'
+  discharge_energy: 'float64'
+  charge_energy: 'float64'
+  temperature_maximum: 'float32'
+  temperature_average: 'float32'
+  temperature_minimum: 'float32'
+  date_time_iso: 'object'
+  cycle_index: 'int32'
+  coulombic_efficiency: 'float64'
+  paused: 'int8'
+  cycle_type: 'category'
+
+diagnostic_interpolated:
+  voltage: 'float32'
+  current: 'float32'
+  charge_capacity: 'float64'
+  discharge_capacity: 'float64'
+  charge_energy: 'float64'
+  discharge_energy: 'float64'
+  internal_resistance: 'float32'
+  temperature: 'float32'
+  test_time: 'float64'
+  date_time_iso: 'object'
+  cycle_index: 'int32'
+  cycle_type: 'category'
+  step_index: 'int16'
+  step_index_counter: 'int16'
+  step_type: 'category'
+  discharge_dQdV: 'float64'
+  charge_dQdV: 'float64'
+
+
+
+
+

--- a/beep/structure.py
+++ b/beep/structure.py
@@ -1054,7 +1054,6 @@ class ProcessedCyclerRun(MSONable):
         """MSONable deserialization method"""
         for obj, dtype_dict in STRUCTURE_DTYPES.items():
             for column, dtype in dtype_dict.items():
-                # TODO: refactor with pydash
                 if d.get(obj) is not None:
                     if d[obj].get(column) is not None:
                         d[obj][column] = pd.Series(d[obj][column], dtype=dtype)

--- a/beep/structure.py
+++ b/beep/structure.py
@@ -1052,6 +1052,13 @@ class ProcessedCyclerRun(MSONable):
             beep.structure.ProcessedCyclerRun: deserialized ProcessedCyclerRun.
         """
         """MSONable deserialization method"""
+        for obj, dtype_dict in STRUCTURE_DTYPES.items():
+            for column, dtype in dtype_dict.items():
+                # TODO: refactor with pydash
+                if d.get(obj) is not None:
+                    if d[obj].get(column) is not None:
+                        d[obj][column] = pd.Series(d[obj][column], dtype=dtype)
+
         d['cycles_interpolated'] = pd.DataFrame(d['cycles_interpolated'])
         d['summary'] = pd.DataFrame(d['summary'])
         d['diagnostic_summary'] = pd.DataFrame(d.get('diagnostic_summary'))

--- a/beep/structure.py
+++ b/beep/structure.py
@@ -59,7 +59,8 @@ from beep import StringIO, MODULE_DIR, ENVIRONMENT
 from beep.validate import ValidatorBeep, BeepValidationError
 from beep.collate import add_suffix_to_filename
 from beep.conversion_schemas import ARBIN_CONFIG, MACCOR_CONFIG, \
-    FastCharge_CONFIG, xTesladiag_CONFIG, INDIGO_CONFIG, BIOLOGIC_CONFIG
+    FastCharge_CONFIG, xTesladiag_CONFIG, INDIGO_CONFIG, BIOLOGIC_CONFIG, \
+    STRUCTURE_DTYPES
 from beep.utils import KinesisEvents
 from beep import logger, __version__
 
@@ -145,8 +146,7 @@ class RawCyclerRun(MSONable):
                 the voltage interpolation range endpoints.
             resolution (int): resolution of interpolated data.
             step_type (str): which step to interpolate i.e. 'charge' or 'discharge'
-            diag_cycles (dict): dictionary containing information about
-                location of diagnostic cycles
+            reg_cycles (dict): list containing cycle indicies of regular cycles
 
         Returns:
             pandas.DataFrame: DataFrame corresponding to interpolated values.
@@ -158,7 +158,7 @@ class RawCyclerRun(MSONable):
         else:
             raise ValueError("{} is not a recognized step type")
         incl_columns = ["current", "charge_capacity", "discharge_capacity",
-                        "internal_resistance", "temperature", "cycle_index"]
+                        "internal_resistance", "temperature"]
         all_dfs = []
         cycle_indices = self.data.cycle_index.unique()
         cycle_indices = [c for c in cycle_indices if c in reg_cycles]
@@ -170,9 +170,9 @@ class RawCyclerRun(MSONable):
                 continue
             new_df = get_interpolated_data(new_df, "voltage", field_range=v_range,
                                            columns=incl_columns, resolution=resolution)
-            new_df.cycle_index = cycle_index
+            new_df['cycle_index'] = cycle_index
             new_df['step_type'] = step_type
-            new_df['step_type'].astype('category')
+            new_df['step_type'] = new_df['step_type'].astype('category')
             all_dfs.append(new_df)
 
         # Ignore the index to avoid issues with overlapping voltages
@@ -216,6 +216,7 @@ class RawCyclerRun(MSONable):
                                                           step_type='charge',
                                                           reg_cycles=reg_cycles)
         result = pd.concat([interpolated_discharge, interpolated_charge], ignore_index=True)
+        result = result.astype(STRUCTURE_DTYPES['cycles_interpolated'])
 
         return result
 
@@ -331,6 +332,8 @@ class RawCyclerRun(MSONable):
         # Determine if any of the cycles has been paused
         summary['paused'] = self.data.groupby("cycle_index").apply(determine_paused)
 
+        summary = summary.astype(STRUCTURE_DTYPES['summary'])
+
         last_voltage = self.data.loc[self.data['cycle_index'] == self.data['cycle_index'].max()]['voltage']
         if ((last_voltage.min() < cycle_complete_vmin) and (last_voltage.max() > cycle_complete_vmax) and
             ((summary.iloc[[-1]])['discharge_capacity'].iloc[0] > cycle_complete_discharge_ratio
@@ -383,6 +386,8 @@ class RawCyclerRun(MSONable):
         diag_summary.reset_index(drop=True, inplace=True)
 
         diag_summary['cycle_type'] = pd.Series(diagnostic_available['cycle_type'] * len(starts_at))
+
+        diag_summary = diag_summary.astype(STRUCTURE_DTYPES['diagnostic_summary'])
 
         return diag_summary
 
@@ -488,6 +493,9 @@ class RawCyclerRun(MSONable):
         result = pd.concat(all_dfs, ignore_index=True)
         # Cycle_index gets a little weird about typing, so round it here
         result.cycle_index = result.cycle_index.round()
+
+        result = result.astype(STRUCTURE_DTYPES['diagnostic_interpolated'])
+
         return result
 
     @classmethod

--- a/beep/tests/test_structure.py
+++ b/beep/tests/test_structure.py
@@ -16,6 +16,7 @@ from beep.structure import RawCyclerRun, ProcessedCyclerRun, \
     process_file_list_from_json, EISpectrum, get_project_sequence, \
     get_protocol_parameters, get_diagnostic_parameters, \
     determine_paused
+from beep.conversion_schemas import STRUCTURE_DTYPES
 from monty.serialization import loadfn, dumpfn
 from monty.tempfile import ScratchDir
 from beep.utils import os_format
@@ -169,6 +170,41 @@ class RawCyclerRunTest(unittest.TestCase):
         self.assertTrue(np.all(np.array(lengths) == 1000))
         self.assertTrue(all_interpolated['current'].mean() > 0)
 
+    def test_interpolated_cycles_dtypes(self):
+        cycler_run = RawCyclerRun.from_file(self.arbin_file)
+        all_interpolated = cycler_run.get_interpolated_cycles()
+        cycles_interpolated_dyptes = all_interpolated.dtypes.tolist()
+        cycles_interpolated_columns = all_interpolated.columns.tolist()
+        cycles_interpolated_dyptes = [str(dtyp) for dtyp in cycles_interpolated_dyptes]
+        for indx, col in enumerate(cycles_interpolated_columns):
+            self.assertEqual(cycles_interpolated_dyptes[indx], STRUCTURE_DTYPES['cycles_interpolated'][col])
+
+        cycler_run = RawCyclerRun.from_maccor_file(self.maccor_file_w_diagnostics, include_eis=False)
+        all_interpolated = cycler_run.get_interpolated_cycles()
+        cycles_interpolated_dyptes = all_interpolated.dtypes.tolist()
+        cycles_interpolated_columns = all_interpolated.columns.tolist()
+        cycles_interpolated_dyptes = [str(dtyp) for dtyp in cycles_interpolated_dyptes]
+        for indx, col in enumerate(cycles_interpolated_columns):
+            self.assertEqual(cycles_interpolated_dyptes[indx], STRUCTURE_DTYPES['cycles_interpolated'][col])
+
+    def test_summary_dtypes(self):
+        cycler_run = RawCyclerRun.from_file(self.arbin_file)
+        all_summary = cycler_run.get_summary()
+        cycles_interpolated_dyptes = all_summary.dtypes.tolist()
+        cycles_interpolated_columns = all_summary.columns.tolist()
+        cycles_interpolated_dyptes = [str(dtyp) for dtyp in cycles_interpolated_dyptes]
+        for indx, col in enumerate(cycles_interpolated_columns):
+            self.assertEqual(cycles_interpolated_dyptes[indx], STRUCTURE_DTYPES['summary'][col])
+
+        cycler_run = RawCyclerRun.from_maccor_file(self.maccor_file_w_diagnostics, include_eis=False)
+        all_summary = cycler_run.get_summary()
+        cycles_interpolated_dyptes = all_summary.dtypes.tolist()
+        cycles_interpolated_columns = all_summary.columns.tolist()
+        cycles_interpolated_dyptes = [str(dtyp) for dtyp in cycles_interpolated_dyptes]
+        for indx, col in enumerate(cycles_interpolated_columns):
+            self.assertEqual(cycles_interpolated_dyptes[indx], STRUCTURE_DTYPES['summary'][col])
+
+
     @unittest.skipUnless(BIG_FILE_TESTS, SKIP_MSG)
     def test_get_diagnostic(self):
         os.environ['BEEP_ROOT'] = TEST_FILE_DIR
@@ -181,6 +217,13 @@ class RawCyclerRunTest(unittest.TestCase):
         self.assertEqual(v_range, [2.7, 4.2])
         self.assertEqual(diagnostic_available['cycle_type'], ['reset', 'hppc', 'rpt_0.2C', 'rpt_1C', 'rpt_2C'])
         diag_summary = cycler_run.get_diagnostic_summary(diagnostic_available)
+
+        diag_dyptes = diag_summary.dtypes.tolist()
+        diag_columns = diag_summary.columns.tolist()
+        diag_dyptes = [str(dtyp) for dtyp in diag_dyptes]
+        for indx, col in enumerate(diag_columns):
+            self.assertEqual(diag_dyptes[indx], STRUCTURE_DTYPES['diagnostic_summary'][col])
+
         self.assertEqual(diag_summary.cycle_index.tolist(), [1, 2, 3, 4, 5,
                                                              36, 37, 38, 39, 40,
                                                              141, 142, 143, 144, 145,
@@ -193,6 +236,13 @@ class RawCyclerRunTest(unittest.TestCase):
                                                             ])
         self.assertEqual(diag_summary.paused.max(), 0)
         diag_interpolated = cycler_run.get_interpolated_diagnostic_cycles(diagnostic_available, resolution=1000)
+
+        diag_dyptes = diag_interpolated.dtypes.tolist()
+        diag_columns = diag_interpolated.columns.tolist()
+        diag_dyptes = [str(dtyp) for dtyp in diag_dyptes]
+        for indx, col in enumerate(diag_columns):
+            self.assertEqual(diag_dyptes[indx], STRUCTURE_DTYPES['diagnostic_interpolated'][col])
+
         diag_cycle = diag_interpolated[(diag_interpolated.cycle_type == 'rpt_0.2C')
                                        & (diag_interpolated.step_type == 1)]
         self.assertEqual(diag_cycle.cycle_index.unique().tolist(), [3, 38, 143])
@@ -212,7 +262,7 @@ class RawCyclerRunTest(unittest.TestCase):
                                          & (diag_interpolated.step_type == 2)
                                          & (diag_interpolated.step_index_counter == 3)
                                          & ~pd.isnull(diag_interpolated.current)]
-        print(hppc_dischg1)
+
         plt.figure()
         plt.plot(hppc_dischg1.test_time, hppc_dischg1.voltage)
         plt.savefig(os.path.join(TEST_FILE_DIR, "hppc_discharge_pulse_1.png"))
@@ -238,7 +288,7 @@ class RawCyclerRunTest(unittest.TestCase):
 
         self.assertTrue(interp3.current.mean() > 0)
         self.assertEqual(len(interp3.voltage), 10000)
-        self.assertEqual(interp3.voltage.median(), 3.6)
+        self.assertEqual(interp3.voltage.median(), np.float32(3.6))
         np.testing.assert_almost_equal(interp3[interp3.voltage <= interp3.voltage.median()].current.iloc[0],
                                        2.4227011, decimal=6)
 
@@ -287,8 +337,8 @@ class RawCyclerRunTest(unittest.TestCase):
     def test_get_charge_throughput(self):
         cycler_run = RawCyclerRun.from_file(self.arbin_file)
         summary = cycler_run.get_summary(nominal_capacity=4.7, full_fast_charge=0.8)
-        self.assertEqual(summary['charge_throughput'][5], 6.7614094)
-        self.assertEqual(summary['energy_throughput'][5], 23.2752363)
+        self.assertEqual(summary['charge_throughput'][5], np.float32(6.7614093))
+        self.assertEqual(summary['energy_throughput'][5], np.float32(23.2752363))
 
     def test_ingestion_indigo(self):
 

--- a/beep/tests/test_structure.py
+++ b/beep/tests/test_structure.py
@@ -190,19 +190,19 @@ class RawCyclerRunTest(unittest.TestCase):
     def test_summary_dtypes(self):
         cycler_run = RawCyclerRun.from_file(self.arbin_file)
         all_summary = cycler_run.get_summary()
-        cycles_interpolated_dyptes = all_summary.dtypes.tolist()
-        cycles_interpolated_columns = all_summary.columns.tolist()
-        cycles_interpolated_dyptes = [str(dtyp) for dtyp in cycles_interpolated_dyptes]
-        for indx, col in enumerate(cycles_interpolated_columns):
-            self.assertEqual(cycles_interpolated_dyptes[indx], STRUCTURE_DTYPES['summary'][col])
+        reg_dyptes = all_summary.dtypes.tolist()
+        reg_columns = all_summary.columns.tolist()
+        reg_dyptes = [str(dtyp) for dtyp in reg_dyptes]
+        for indx, col in enumerate(reg_columns):
+            self.assertEqual(reg_dyptes[indx], STRUCTURE_DTYPES['summary'][col])
 
         cycler_run = RawCyclerRun.from_maccor_file(self.maccor_file_w_diagnostics, include_eis=False)
         all_summary = cycler_run.get_summary()
-        cycles_interpolated_dyptes = all_summary.dtypes.tolist()
-        cycles_interpolated_columns = all_summary.columns.tolist()
-        cycles_interpolated_dyptes = [str(dtyp) for dtyp in cycles_interpolated_dyptes]
-        for indx, col in enumerate(cycles_interpolated_columns):
-            self.assertEqual(cycles_interpolated_dyptes[indx], STRUCTURE_DTYPES['summary'][col])
+        reg_dyptes = all_summary.dtypes.tolist()
+        reg_columns = all_summary.columns.tolist()
+        reg_dyptes = [str(dtyp) for dtyp in reg_dyptes]
+        for indx, col in enumerate(reg_columns):
+            self.assertEqual(reg_dyptes[indx], STRUCTURE_DTYPES['summary'][col])
 
 
     @unittest.skipUnless(BIG_FILE_TESTS, SKIP_MSG)
@@ -274,8 +274,21 @@ class RawCyclerRunTest(unittest.TestCase):
         dumpfn(processed_cycler_run, processed_cycler_run_loc)
         proc_size = os.path.getsize(processed_cycler_run_loc)
         self.assertLess(proc_size, 29000000)
+
         test = loadfn(processed_cycler_run_loc)
         self.assertIsInstance(test.diagnostic_summary, pd.DataFrame)
+        diag_dyptes = test.diagnostic_summary.dtypes.tolist()
+        diag_columns = test.diagnostic_summary.columns.tolist()
+        diag_dyptes = [str(dtyp) for dtyp in diag_dyptes]
+        for indx, col in enumerate(diag_columns):
+            self.assertEqual(diag_dyptes[indx], STRUCTURE_DTYPES['diagnostic_summary'][col])
+
+        diag_dyptes = test.diagnostic_interpolated.dtypes.tolist()
+        diag_columns = test.diagnostic_interpolated.columns.tolist()
+        diag_dyptes = [str(dtyp) for dtyp in diag_dyptes]
+        for indx, col in enumerate(diag_columns):
+            self.assertEqual(diag_dyptes[indx], STRUCTURE_DTYPES['diagnostic_interpolated'][col])
+
         os.remove(processed_cycler_run_loc)
 
     def test_get_interpolated_cycles_maccor(self):
@@ -568,6 +581,23 @@ class ProcessedCyclerRunTest(unittest.TestCase):
         pcycler_run = loadfn(self.pcycler_run_file)
         self.assertEqual(pcycler_run.get_cycle_life(30,0.99), 82)
         self.assertEqual(pcycler_run.get_cycle_life(),189)
+
+    def test_data_types_old_processed(self):
+        pcycler_run = loadfn(self.pcycler_run_file)
+
+        all_summary = pcycler_run.summary
+        reg_dyptes = all_summary.dtypes.tolist()
+        reg_columns = all_summary.columns.tolist()
+        reg_dyptes = [str(dtyp) for dtyp in reg_dyptes]
+        for indx, col in enumerate(reg_columns):
+            self.assertEqual(reg_dyptes[indx], STRUCTURE_DTYPES['summary'][col])
+
+        all_interpolated = pcycler_run.cycles_interpolated
+        cycles_interpolated_dyptes = all_interpolated.dtypes.tolist()
+        cycles_interpolated_columns = all_interpolated.columns.tolist()
+        cycles_interpolated_dyptes = [str(dtyp) for dtyp in cycles_interpolated_dyptes]
+        for indx, col in enumerate(cycles_interpolated_columns):
+            self.assertEqual(cycles_interpolated_dyptes[indx], STRUCTURE_DTYPES['cycles_interpolated'][col])
 
     def test_cycles_to_reach_set_capacities(self):
         pcycler_run = loadfn(self.pcycler_run_file)


### PR DESCRIPTION
This PR adds type casting for the structured data in an attempt to reduce memory required for subsequent processing.
- Schema for data types in each of the structured dataframes
- `astype` calls to cast each dataframe to those data types upon creation
- tests to ensure that data is typed correctly
- logic around reloading dataframes and casting the data types

Memory usage of `diagnostic_interpolated` and `cycles_interpolated` before and after data typing
<img width="391" alt="Screen Shot 2020-04-20 at 12 47 32 AM" src="https://user-images.githubusercontent.com/36210728/79726988-87074400-82a0-11ea-94d7-7163cf815149.png">
