### PR TITLE
Change logging to stdout to cleaner method

### DIFF
--- a/beep/config.py
+++ b/beep/config.py
@@ -39,7 +39,7 @@ config = {
     'stage': {
         'logging': {
             'container': 'BEEP_EP',
-            'streams': ['CloudWatch']
+            'streams': ['CloudWatch', 'stdout']
         },
         'kinesis': {
             'stream': 'stage/beep/eventstream/stage'

--- a/beep/featurize.py
+++ b/beep/featurize.py
@@ -430,22 +430,14 @@ def main():
     # Parse args and construct initial cycler run
     logger.info('starting', extra=s)
     logger.info('Running version=%s', __version__, extra=s)
-    if ENVIRONMENT == 'stage':
-        print('starting')
     try:
         args = docopt(__doc__)
         input_json = args['INPUT_JSON']
-        if ENVIRONMENT == 'stage':
-            print(input_json)
         print(process_file_list_from_json(input_json), end="")
     except Exception as e:
         logger.error(str(e), extra=s)
-        if ENVIRONMENT == 'stage':
-            print(str(e))
         raise e
     logger.info('finish', extra=s)
-    if ENVIRONMENT == 'stage':
-        print('finish')
     return None
 
 

--- a/beep/run_model.py
+++ b/beep/run_model.py
@@ -596,26 +596,17 @@ def main():
     # Parse args and construct initial cycler run
     logger.info('starting', extra=s)
     logger.info('Running version=%s', __version__, extra=s)
-    if ENVIRONMENT == 'stage':
-        print('starting')
     try:
         args = docopt(__doc__)
         input_json = args['INPUT_JSON']
-        if ENVIRONMENT == 'stage':
-            print(input_json)
         if args['--fit']:
             print(process_file_list_from_json(input_json, predict_only=False, model_dir=MODEL_DIR), end="")
         else:
             print(process_file_list_from_json(input_json, model_dir=MODEL_DIR), end="")
-
     except Exception as e:
         logger.error(str(e), extra=s)
-        if ENVIRONMENT == 'stage':
-            print(str(e))
         raise e
     logger.info('finish', extra=s)
-    if ENVIRONMENT == 'stage':
-        print('finish')
     return None
 
 

--- a/beep/structure.py
+++ b/beep/structure.py
@@ -1559,22 +1559,14 @@ def main():
     """
     logger.info('starting', extra=s)
     logger.info('Running version=%s', __version__, extra=s)
-    if ENVIRONMENT == 'stage':
-        print('starting')
     try:
         args = docopt(__doc__)
         input_json = args['INPUT_JSON']
-        if ENVIRONMENT == 'stage':
-            print(input_json)
         print(process_file_list_from_json(input_json))
     except Exception as e:
         logger.error(str(e), extra=s)
-        if ENVIRONMENT == 'stage':
-            print(str(e))
         raise e
     logger.info('finish', extra=s)
-    if ENVIRONMENT == 'stage':
-        print('finish')
     return None
 
 

--- a/beep/validate.py
+++ b/beep/validate.py
@@ -553,22 +553,14 @@ def validate_file_list_from_json(file_list_json, record_results=False,
 def main():
     logger.info('starting', extra=s)
     logger.info('Running version=%s', __version__, extra=s)
-    if ENVIRONMENT == 'stage':
-        print('starting')
     try:
         args = docopt(__doc__)
         input_json = args['INPUT_JSON']
-        if ENVIRONMENT == 'stage':
-            print(input_json)
         print(validate_file_list_from_json(input_json), end="")
     except Exception as e:
         logger.error(str(e), extra=s)
-        if ENVIRONMENT == 'stage':
-            print(str(e))
         raise e
     logger.info('finish', extra=s)
-    if ENVIRONMENT == 'stage':
-        print('finish')
     return None
 
 


### PR DESCRIPTION
This PR changes the way that logging to stdout is done in a stage environment to more closely mirror BEEP-Sync (which is cleaner and easier). It also adds some retry logic around setting up the logger so that credential errors don't immediately cause the container to crash.