### PR TITLE
Add retry logic to events

### DIFF
--- a/beep/__init__.py
+++ b/beep/__init__.py
@@ -32,7 +32,7 @@ if VERSION_TAG is not None:
 tqdm = partial(_tqdm, disable=bool(os.environ.get("TQDM_OFF")))
 
 ENV_VAR = 'BEEP_ENV'
-MAX_RETRIES = 5
+MAX_RETRIES = 12
 
 # environment
 ENVIRONMENT = os.getenv(ENV_VAR)


### PR DESCRIPTION
This PR adds retry logic around getting the secret for the event stream. I am not sure why this is necessary since the credentials must be available for initializing the logger to get to this point, but it's possible that the method for getting credentials is slightly different for secrets.