### PR TITLE
Fix charge step interpolation for regular cycles

### DIFF
--- a/beep/featurize.py
+++ b/beep/featurize.py
@@ -388,8 +388,8 @@ def process_file_list_from_json(file_list_json, processed_dir='data-share/featur
             processed_paths_list.append(path)
             processed_run_list.append(run_id)
             processed_result_list.append("incomplete")
-            processed_message_list.append({'comment':'Insufficient data for featurization',
-                                            'error': ''})
+            processed_message_list.append({'comment': 'Insufficient data for featurization',
+                                           'error': ''})
 
         else:
             processed_data = DegradationPredictor.from_processed_cycler_run_file(
@@ -409,7 +409,7 @@ def process_file_list_from_json(file_list_json, processed_dir='data-share/featur
             processed_run_list.append(run_id)
             processed_result_list.append("success")
             processed_message_list.append({'comment': '',
-                                            'error': ''})
+                                           'error': ''})
 
     output_data = {"file_list": processed_paths_list,
                    "run_list": processed_run_list,

--- a/beep/featurize.py
+++ b/beep/featurize.py
@@ -137,7 +137,12 @@ class DegradationPredictor(MSONable):
         assert len(processed_cycler_run.summary) > final_pred_cycle, 'cycle count must exceed final_pred_cycle'
         cycles_to_average_over = 40  # For nominal capacity, use median discharge capacity of first n cycles
 
-        interpolated_df = processed_cycler_run.cycles_interpolated
+        if 'step_type' in processed_cycler_run.cycles_interpolated.columns:
+            interpolated_df = processed_cycler_run.cycles_interpolated[
+                processed_cycler_run.cycles_interpolated.step_type == 'discharge']
+        else:
+            interpolated_df = processed_cycler_run.cycles_interpolated
+
         X = pd.DataFrame(np.zeros((1, 20)))
         labels = []
         # Discharge capacity, cycle 2 = Q(n=2)

--- a/beep/featurize.py
+++ b/beep/featurize.py
@@ -137,6 +137,7 @@ class DegradationPredictor(MSONable):
         assert len(processed_cycler_run.summary) > final_pred_cycle, 'cycle count must exceed final_pred_cycle'
         cycles_to_average_over = 40  # For nominal capacity, use median discharge capacity of first n cycles
 
+        # Features in "nature energy" set only use discharge portion of the cycle
         if 'step_type' in processed_cycler_run.cycles_interpolated.columns:
             interpolated_df = processed_cycler_run.cycles_interpolated[
                 processed_cycler_run.cycles_interpolated.step_type == 'discharge']

--- a/beep/structure.py
+++ b/beep/structure.py
@@ -137,7 +137,7 @@ class RawCyclerRun(MSONable):
         else:
             raise ValueError("{} does not match any known file pattern".format(path))
 
-    def get_interpolated_steps(self, v_range, resolution, step_type='discharge', reg_cycles=None):
+    def get_interpolated_steps(self, v_range, resolution, step_type='discharge', reg_cycles=None, axis='voltage'):
         """
         Gets interpolated cycles for the step specified, charge or discharge.
 
@@ -146,7 +146,8 @@ class RawCyclerRun(MSONable):
                 the voltage interpolation range endpoints.
             resolution (int): resolution of interpolated data.
             step_type (str): which step to interpolate i.e. 'charge' or 'discharge'
-            reg_cycles (dict): list containing cycle indicies of regular cycles
+            reg_cycles (list): list containing cycle indicies of regular cycles
+            axis (str): which column to use for interpolation
 
         Returns:
             pandas.DataFrame: DataFrame corresponding to interpolated values.
@@ -157,7 +158,7 @@ class RawCyclerRun(MSONable):
             step_filter = determine_whether_step_is_charging
         else:
             raise ValueError("{} is not a recognized step type")
-        incl_columns = ["current", "charge_capacity", "discharge_capacity",
+        incl_columns = ["voltage", "current", "charge_capacity", "discharge_capacity",
                         "internal_resistance", "temperature"]
         all_dfs = []
         cycle_indices = self.data.cycle_index.unique()
@@ -168,8 +169,13 @@ class RawCyclerRun(MSONable):
             new_df = self.data.loc[self.data["cycle_index"] == cycle_index].groupby("step_index").filter(step_filter)
             if new_df.size == 0:
                 continue
-            new_df = get_interpolated_data(new_df, "voltage", field_range=v_range,
-                                           columns=incl_columns, resolution=resolution)
+            if axis != 'voltage':
+                axis_range = [new_df[axis].min(), new_df[axis].max()]
+                new_df = get_interpolated_data(new_df, axis, field_range=axis_range,
+                                               columns=incl_columns, resolution=resolution)
+            else:
+                new_df = get_interpolated_data(new_df, axis, field_range=v_range,
+                                               columns=incl_columns, resolution=resolution)
             new_df['cycle_index'] = cycle_index
             new_df['step_type'] = step_type
             new_df['step_type'] = new_df['step_type'].astype('category')
@@ -210,11 +216,13 @@ class RawCyclerRun(MSONable):
         interpolated_discharge = self.get_interpolated_steps(v_range,
                                                              resolution,
                                                              step_type='discharge',
-                                                             reg_cycles=reg_cycles)
+                                                             reg_cycles=reg_cycles,
+                                                             axis='voltage')
         interpolated_charge = self.get_interpolated_steps(v_range,
                                                           resolution,
                                                           step_type='charge',
-                                                          reg_cycles=reg_cycles)
+                                                          reg_cycles=reg_cycles,
+                                                          axis='charge_capacity')
         result = pd.concat([interpolated_discharge, interpolated_charge], ignore_index=True)
         result = result.astype(STRUCTURE_DTYPES['cycles_interpolated'])
 
@@ -852,7 +860,7 @@ class ProcessedCyclerRun(MSONable):
             channel_id (int): id for the channel for the experiment
             summary (pandas.DataFrame): data of summary data for each cycle
             cycles_interpolated (pandas.DataFrame): interpolated data for
-                discharge over 2.8-3.5
+                regular cycles
         """
         self.barcode = barcode
         self.protocol = protocol
@@ -862,12 +870,10 @@ class ProcessedCyclerRun(MSONable):
         # We can drop this restriction later if we don't need it
         min_index = cycles_interpolated.cycle_index.min()
         if 'step_type' in cycles_interpolated.columns:
-            cycles_interpolated = cycles_interpolated[(cycles_interpolated.step_type == 'discharge')]
-        min_index_df = cycles_interpolated[(cycles_interpolated.cycle_index == min_index)]
-        matches = cycles_interpolated.groupby("cycle_index").apply(
-            lambda x: np.allclose(x.voltage.values, min_index_df.voltage.values))
-        if not np.all(matches):
-            raise ValueError("cycles_interpolated are not uniform")
+            min_index_df = cycles_interpolated[(cycles_interpolated.cycle_index == min_index) &
+                                               (cycles_interpolated.step_type == 'discharge')]
+        else:
+            min_index_df = cycles_interpolated[(cycles_interpolated.cycle_index == min_index)]
         self.v_interpolated = min_index_df.voltage.values
 
         self.cycles_interpolated = cycles_interpolated

--- a/beep/structure.py
+++ b/beep/structure.py
@@ -169,13 +169,15 @@ class RawCyclerRun(MSONable):
             new_df = self.data.loc[self.data["cycle_index"] == cycle_index].groupby("step_index").filter(step_filter)
             if new_df.size == 0:
                 continue
-            if axis != 'voltage':
+            if axis in ['charge_capacity', 'discharge_capacity', 'test_time']:
                 axis_range = [new_df[axis].min(), new_df[axis].max()]
                 new_df = get_interpolated_data(new_df, axis, field_range=axis_range,
                                                columns=incl_columns, resolution=resolution)
-            else:
+            elif axis == 'voltage':
                 new_df = get_interpolated_data(new_df, axis, field_range=v_range,
                                                columns=incl_columns, resolution=resolution)
+            else:
+                raise NotImplementedError
             new_df['cycle_index'] = cycle_index
             new_df['step_type'] = step_type
             new_df['step_type'] = new_df['step_type'].astype('category')

--- a/beep/tests/test_secrets_manager.py
+++ b/beep/tests/test_secrets_manager.py
@@ -1,0 +1,24 @@
+# Copyright 2019 Toyota Research Institute. All rights reserved.
+"""Unit tests related to Splicing files"""
+
+import os
+import unittest
+from beep import ENVIRONMENT
+from beep.config import config
+from beep.utils.secrets_manager import secret_accessible, get_secret
+
+TEST_DIR = os.path.dirname(__file__)
+TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
+
+
+class SecretTest(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_secret_accessible(self):
+        available = secret_accessible(ENVIRONMENT)
+        if available:
+            secret_name = config[ENVIRONMENT]['kinesis']['stream']
+            get_secret(secret_name)
+        else:
+            self.assertFalse(available)

--- a/beep/utils/project_transfer.py
+++ b/beep/utils/project_transfer.py
@@ -103,7 +103,7 @@ class ProjectTransfer:
 if __name__ == "__main__":
     transfer = ProjectTransfer("PredictionDiagnostics",
                                "PreDiag",
-                               "beep-input-data",
+                               "beep-input-data-stage",
                                "d3Batt/raw/maccor/STANFORD LOANER #2")
     # List of strings here can be used to filer out specific file names so that not all files are transferred over
     # '_000052' is a file generated using an even earlier version of the protocol and probably should not be transferred

--- a/beep/utils/secrets_manager.py
+++ b/beep/utils/secrets_manager.py
@@ -17,9 +17,9 @@ from beep.config import config
 
 
 def secret_accessible(environment):
-    pg_config = config[environment]['postgres']
-    if 'secret' in pg_config:
-        secret_name = pg_config['secret']
+    event_config = config[environment]['kinesis']
+    if 'stream' in event_config:
+        secret_name = event_config['stream']
         try:
             _ = get_secret(secret_name)
         except Exception as e:


### PR DESCRIPTION
This PR fixes some errors with the interpolation for regular cycles. Memory usage might be increased as a result, although this interpolation was already being done so the effect should be minimal. The processed object is significantly larger on disk (29MB -> 47MB). However, this change is necessary to complete some research on degradation features.
- Removes code that was deleting the charge step from regular cycles
- Changes charge interpolation to be based on capacity instead of voltage