### PR TITLE
Change the interpolation axis to be the max range across the run

### DIFF
--- a/beep/structure.py
+++ b/beep/structure.py
@@ -169,8 +169,12 @@ class RawCyclerRun(MSONable):
             new_df = self.data.loc[self.data["cycle_index"] == cycle_index].groupby("step_index").filter(step_filter)
             if new_df.size == 0:
                 continue
-            if axis in ['charge_capacity', 'discharge_capacity', 'test_time']:
+            if axis in ['charge_capacity', 'discharge_capacity']:
                 axis_range = [self.data[axis].min(), self.data[axis].max()]
+                new_df = get_interpolated_data(new_df, axis, field_range=axis_range,
+                                               columns=incl_columns, resolution=resolution)
+            elif axis == 'test_time':
+                axis_range = [new_df[axis].min(), new_df[axis].max()]
                 new_df = get_interpolated_data(new_df, axis, field_range=axis_range,
                                                columns=incl_columns, resolution=resolution)
             elif axis == 'voltage':

--- a/beep/structure.py
+++ b/beep/structure.py
@@ -170,7 +170,7 @@ class RawCyclerRun(MSONable):
             if new_df.size == 0:
                 continue
             if axis in ['charge_capacity', 'discharge_capacity', 'test_time']:
-                axis_range = [new_df[axis].min(), new_df[axis].max()]
+                axis_range = [self.data[axis].min(), self.data[axis].max()]
                 new_df = get_interpolated_data(new_df, axis, field_range=axis_range,
                                                columns=incl_columns, resolution=resolution)
             elif axis == 'voltage':

--- a/beep/tests/test_structure.py
+++ b/beep/tests/test_structure.py
@@ -167,6 +167,9 @@ class RawCyclerRunTest(unittest.TestCase):
         all_interpolated = cycler_run.get_interpolated_cycles()
         all_interpolated = all_interpolated[(all_interpolated.step_type == 'charge')]
         lengths = [len(df) for index, df in all_interpolated.groupby("cycle_index")]
+        axis_1 = all_interpolated[all_interpolated.cycle_index == 5].charge_capacity.to_list()
+        axis_2 = all_interpolated[all_interpolated.cycle_index == 10].charge_capacity.to_list()
+        self.assertEqual(axis_1, axis_2)
         self.assertTrue(np.all(np.array(lengths) == 1000))
         self.assertTrue(all_interpolated['current'].mean() > 0)
 

--- a/beep/tests/test_structure.py
+++ b/beep/tests/test_structure.py
@@ -162,6 +162,23 @@ class RawCyclerRunTest(unittest.TestCase):
         for col_name in y_at_point.columns:
             self.assertAlmostEqual(pred[col_name].iloc[0], y_at_point[col_name].iloc[0], places=5)
 
+    def test_get_interpolated_charge_step(self):
+        cycler_run = RawCyclerRun.from_file(self.arbin_file)
+        reg_cycles = [i for i in cycler_run.data.cycle_index.unique()]
+        v_range = [2.8, 3.5]
+        resolution = 1000
+        interpolated_charge = cycler_run.get_interpolated_steps(v_range,
+                                                                resolution,
+                                                                step_type='charge',
+                                                                reg_cycles=reg_cycles,
+                                                                axis='test_time')
+        lengths = [len(df) for index, df in interpolated_charge.groupby("cycle_index")]
+        axis_1 = interpolated_charge[interpolated_charge.cycle_index == 5].charge_capacity.to_list()
+        axis_2 = interpolated_charge[interpolated_charge.cycle_index == 10].charge_capacity.to_list()
+        self.assertGreater(max(axis_1), max(axis_2))
+        self.assertTrue(np.all(np.array(lengths) == 1000))
+        self.assertTrue(interpolated_charge['current'].mean() > 0)
+
     def test_get_interpolated_charge_cycles(self):
         cycler_run = RawCyclerRun.from_file(self.arbin_file)
         all_interpolated = cycler_run.get_interpolated_cycles()


### PR DESCRIPTION
This PR changes the interpolation axis for regular cycles to be computed as the maximum range in the run instead of just interpolating over the range for each cycle. This is necessary in order to subtract of two capacity-voltage curves from different cycles within the same run, a quantity related to the delta Q feature.