### PR TITLE
Mat 1647 add diagnostic cycles feature classes

### DIFF
--- a/beep/featurize.py
+++ b/beep/featurize.py
@@ -169,8 +169,6 @@ class DiagnosticCyclesFeatures(BeepFeatures):
     # Class name for the feature object
     class_feature_name = 'DiagnosticCyclesFeatures'
     diagnostic_cycle_types = ['reset', 'hppc', 'rpt_0.2C', 'rpt_1C', 'rpt_2C']
-    parameters_path = '/data-share/raw/parameters' if os.path.isdir(
-        '/data-share/raw/parameters') else os.path.join(os.path.dirname(__file__),'tests/test_files/data-share/raw/parameters')
 
     def __init__(self, name, X, metadata):
         """
@@ -322,8 +320,7 @@ class DiagnosticCyclesFeatures(BeepFeatures):
         f3 = featurizer_helpers.get_hppc_ocv(processed_cycler_run, cycles[diag_pos])
         v_diff = featurizer_helpers.get_v_diff(cycles[diag_pos], processed_cycler_run, soc_window)
 
-        params, _ = get_protocol_parameters(processed_cycler_run.protocol.split('.')[0],
-                                            parameters_path=DiagnosticCyclesFeatures.parameters_path)
+        params, _ = get_protocol_parameters(processed_cycler_run.protocol.split('.')[0])
         params = params[['charge_cutoff_voltage', 'discharge_cutoff_voltage']].reset_index(drop=True)
         df_c = pd.DataFrame()
         df_c = df_c.append({'var(v_diff)': np.var(v_diff),

--- a/beep/featurize.py
+++ b/beep/featurize.py
@@ -36,6 +36,7 @@ import os
 import json
 import numpy as np
 import pandas as pd
+import math
 from abc import ABCMeta, abstractmethod
 from docopt import docopt
 from monty.json import MSONable
@@ -43,6 +44,7 @@ from monty.serialization import loadfn, dumpfn
 from scipy.stats import skew, kurtosis
 from beep.collate import scrub_underscore_suffix, add_suffix_to_filename
 from beep.utils import KinesisEvents
+from beep.helpers import featurizer_helpers
 from beep import logger, ENVIRONMENT, __version__
 
 s = {'service': 'DataAnalyzer'}
@@ -129,7 +131,7 @@ class BeepFeatures(MSONable, metaclass=ABCMeta):
             'barcode': processed_cycler_run.barcode,
             'protocol': processed_cycler_run.protocol,
             'channel_id': processed_cycler_run.channel_id
-                }
+        }
         return metadata
 
     def as_dict(self):
@@ -151,6 +153,348 @@ class BeepFeatures(MSONable, metaclass=ABCMeta):
         """MSONable deserialization method"""
         d['X'] = pd.DataFrame(d['X'])
         return cls(**d)
+
+
+class DiagnosticCyclesFeatures(BeepFeatures):
+    """
+    Object corresponding to feature object. Includes constructors
+    to create the features, object names and metadata attributes in the
+    object
+        name (str): predictor object name.
+        X (pandas.DataFrame): features in DataFrame format.
+        metadata (dict): information about the conditions, data
+            and code used to produce features
+    """
+    # Class name for the feature object
+    class_feature_name = 'DiagnosticCyclesFeatures'
+
+    # Class variables
+    init_pred_cycle = 10
+    mid_pred_cycle = 91
+    final_pred_cycle = 100
+
+    def __init__(self, name, X, metadata):
+        """
+        Args:
+            name (str): predictor object name
+            feature_object (pandas.DataFrame): features in DataFrame format.
+            metadata (dict): information about the data and code used to produce features
+        """
+        super().__init__(name, X, metadata)
+        self.name = name
+        self.X = X
+        self.metadata = metadata
+
+    @classmethod
+    def validate_data(cls, processed_cycler_run):
+        """
+        This function determines if the input data has the necessary attributes for
+        creation of this feature class. It should test for all of the possible reasons
+        that feature generation would fail for this particular input data.
+
+        Args:
+            processed_cycler_run (beep.structure.ProcessedCyclerRun): data from cycler run
+        Returns:
+            bool: True/False indication of ability to proceed with feature generation
+        """
+        conditions = []
+        conditions.append(hasattr(processed_cycler_run, 'diagnostic_summary'))
+        conditions.append(hasattr(processed_cycler_run, 'diagnostic_interpolated'))
+
+        return all(conditions)
+
+    @classmethod
+    def features_from_processed_cycler_run(cls, processed_cycler_run):
+        """
+        Generate features listed in early prediction manuscript, primarily related to the
+        so called delta Q feature
+        Args:
+            processed_cycler_run (beep.structure.ProcessedCyclerRun): data from cycler run
+        Returns:
+            pd.DataFrame: features indicative of degradation, derived from the input data
+        """
+
+        rpt_dQdV_features = DiagnosticCyclesFeatures.get_rpt_dQdV_features(processed_cycler_run, diag_ref=0, diag_nr=1,
+                                                                           charge_y_n=1,
+                                                                           rpt_type='rpt_0.2C')
+
+        hppc_features = DiagnosticCyclesFeatures.get_hppc_features(processed_cycler_run,
+                                                                   parameter_file='procedure_templates/PreDiag_parameters - DP.csv')
+
+        fast_charge_features = DiagnosticCyclesFeatures.get_fast_charge_features(processed_cycler_run,
+                                                                                 diagnostic_cycle_type='rpt_0.2C',
+                                                                                 cycle_comp_num=[0, 1], Q_seg=500)
+
+        X = pd.concat([rpt_dQdV_features, fast_charge_features, hppc_features], axis=1)
+
+        return X
+
+    @classmethod
+    def metadata_from_processed_cycler_run(cls, processed_cycler_run):
+        """
+        Gather and generate information useful for filtering or subsetting the
+        training feature objects for subsequent models
+        Args:
+            processed_cycler_run (beep.structure.ProcessedCyclerRun): data from cycler run
+        Returns:
+            dict: information about the data source, conditions under which the run was
+                performed, and other information useful for modeling and prediction
+        """
+        metadata = {
+            'barcode': processed_cycler_run.barcode,
+            'protocol': processed_cycler_run.protocol,
+            'channel_id': processed_cycler_run.channel_id
+        }
+        return metadata
+
+    @staticmethod
+    def get_rpt_dQdV_features(processed_cycler_run, diag_ref=0, diag_nr=1, charge_y_n=1, rpt_type='rpt_0.2C',
+                              plotting_y_n=0):
+        """
+        Generate features out of peakfits to rpt cycles
+
+        Args:
+            processed_cycler_run (beep.structure.ProcessedCyclerRun)
+            diag_ref (int): 0 (default) reference diagnostic cycle
+            diag_nr (int): 1 (default) next diagnostic cycle occurence for a specific cycle_type.
+            For example, if rpt_0.2C occurs at cycle_index = [2,42,147,250.. ],
+            diag_ref = 0 would correspond to cycle_index = 2
+            and diag_nr = 1 would correspond to cycle_index = 42
+
+            charge_y_n (bool): 1 = charge, 0 = discharge
+            rpt_type (str): type of rpt cycle.
+
+        Returns:
+             pd.DataFrame containing features based on gaussian fits to dQdV features in rpt cycles
+        """
+
+        if ((rpt_type == 'rpt_0.2C') and (charge_y_n == 1)):
+            max_nr_peaks = 4
+
+        elif ((rpt_type == 'rpt_0.2C') and (charge_y_n == 0)):
+            max_nr_peaks = 4
+
+        elif ((rpt_type == 'rpt_1C') and (charge_y_n == 1)):
+            max_nr_peaks = 4
+
+        elif ((rpt_type == 'rpt_1C') and (charge_y_n == 0)):
+            max_nr_peaks = 3
+
+        elif ((rpt_type == 'rpt_2C') and (charge_y_n == 1)):
+            max_nr_peaks = 4
+
+        elif ((rpt_type == 'rpt_2C') and (charge_y_n == 0)):
+            max_nr_peaks = 3
+        else:
+            raise InputError("{} is not a valid rpt cycle".format(
+                rpt_type))
+
+        peak_fit_df_ref = featurizer_helpers.generate_dQdV_peak_fits(processed_cycler_run, diag_nr=diag_ref,
+                                                                     charge_y_n=charge_y_n,
+                                                                     rpt_type=rpt_type, plotting_y_n=plotting_y_n,
+                                                                     max_nr_peaks=max_nr_peaks)
+        peak_fit_df = featurizer_helpers.generate_dQdV_peak_fits(processed_cycler_run, diag_nr=diag_nr, charge_y_n=charge_y_n,
+                                              rpt_type=rpt_type, plotting_y_n=plotting_y_n, max_nr_peaks=max_nr_peaks)
+
+        return 1 + (peak_fit_df - peak_fit_df_ref) / peak_fit_df_ref
+
+    @staticmethod
+    def get_hppc_features(processed_cycler_run, file, parameter_file, diag_pos=1, soc_window=7):
+        """
+        This method calculates features based on voltage and resistance changes in hppc and rpt cycles
+        Args:
+            processed_cycler_run (beep.structure.ProcessedCyclerRun):
+            file: a string of the file name to indicate which cell has problem just in case
+            parameter_file (str): path to file containing tabulated project parameters
+            diag_pos (int): diagnostic cycle occurence for a specific <diagnostic_cycle_type>. e.g.
+            if rpt_0.2C, occurs at cycle_index = [2, 42, 147, 249 ...], <diag_pos>=2 would correspond to cycle_index 147
+
+            remaining (float): fraction of the remaining <metric> relative to nominal value.
+            metric (str):  outcome of interest -- discharge energy/discharge capacity
+            diagnostic_cycle_type (str): type of diagnostic cycle to evaluate features at
+            soc_window (int): step index counter corresponding to the soc window of interest.
+
+        Returns:
+            dataframe of features based on voltage and resistance changes over a SOC window in hppc cycles
+        """
+        data = processed_cycler_run.diagnostic_interpolated
+        df = pd.read_csv(parameter_file)
+        df = df.loc[df['cell_type'] == 'Tesla_Model3_21700']
+
+        # replace_map = {'discharge_cutoff_voltage': {2.5: 1, 2.7: 2, 2.75: 3, 3.3: 4,
+        #                                            3.5: 5, 3.7: 6},
+        #               'charge_cutoff_voltage': {3.7: 1, 4.0: 2, 4.1: 3, 4.2: 4}}
+        # df.replace(replace_map, inplace=True)
+        df['charge_cutoff_voltage'] = df['charge_cutoff_voltage'].astype('category')
+        df['discharge_cutoff_voltage'] = df['discharge_cutoff_voltage'].astype('category')
+
+        cycle_hppc = data.loc[data.cycle_type == 'hppc']
+        cycle_hppc = cycle_hppc.loc[cycle_hppc.current.notna()]
+        cycles = cycle_hppc.cycle_index.unique()
+
+        [f2_d, f2_c] = get_hppc_r(processed_cycler_run, cycles[diag_pos])
+        f3 = get_hppc_ocv(processed_cycler_run, cycles[diag_pos])
+        v_diff = get_v_diff(file, cycles[diag_pos], processed_cycler_run, soc_window)
+
+        parameter_df = get_cutoff_voltage(file, parameter_df)
+        df_c = pd.DataFrame()
+        df_c = df_c.append({'var(v_diff)': np.var(v_diff),
+                            'resistance_d': f2_d, 'resistance_c': f2_c,
+                            'var(ocv)': f3}, ignore_index=True)
+        df_c.reset_index(drop=True, inplace=True)
+        parameter_df.reset_index(drop=True, inplace=True)
+        df_c = pd.concat([df_c, parameter_df], axis=1)
+        df_c.reset_index(drop=True, inplace=True)
+
+        return df_c
+
+    @staticmethod
+    def get_fast_charge_features(processed_cycler_run, diagnostic_cycle_type, cycle_comp_num=[0, 1], Q_seg=500):
+        """
+        Generate features listed in early prediction manuscript using both diagnostic and regular cycles
+
+        Args:
+            processed_cycler_run (beep.structure.ProcessedCyclerRun)
+            diagnostic_cycle_type (str): Describes which cyle type is used for feature creation,
+            options are: 'hppc', 'rpt_0.2C', 'rpt_1C', 'rpt_2C', 'reset'
+            cycle_comp_num (list of two integers): contains numbers of compared cycles [0,1] for e.g.
+            creates the features from the first and the second cycle of the cycle type
+            Q_seg (int):  Number of cycles considered (first 500 for charging, the following 500 for discharging)
+
+
+        Returns:
+            X (pd.DataFrame): Dataframe containing the features
+        """
+
+        diagnostic_interpolated = processed_cycler_run.diagnostic_interpolated
+
+        X = pd.DataFrame(np.zeros((1, 42)))
+        labels = []
+
+        # Determine beginning and end of investigated cycle type
+        index_pos_list = [i for i in range(len(diagnostic_interpolated.cycle_type))
+                          if diagnostic_interpolated.cycle_type[i] == diagnostic_cycle_type]
+
+        end_list = [index_pos_list[i] for i in range(len(index_pos_list) - 1)
+                    if index_pos_list[i + 1] != index_pos_list[i] + 1]
+        start_list = [index_pos_list[i] for i in range(1, len(index_pos_list))
+                      if index_pos_list[i - 1] != index_pos_list[i] - 1]
+        end_list.append(index_pos_list[-1])
+        start_list.insert(0, index_pos_list[0])
+
+        if diagnostic_interpolated.cycle_type[0] == diagnostic_cycle_type:
+            start_list.insert(0, 1)
+        if diagnostic_interpolated.cycle_type[len(diagnostic_interpolated.cycle_type) - 1] == diagnostic_cycle_type:
+            end_list.append(len(diagnostic_interpolated.cycle_type) - 1)
+
+        # Create features
+
+        # Charging Capacity features
+        Qc100_1 = diagnostic_interpolated.charge_capacity[
+                  start_list[cycle_comp_num[1]]: start_list[cycle_comp_num[1]] + Q_seg]
+        Qc10_1 = diagnostic_interpolated.charge_capacity[
+                 start_list[cycle_comp_num[0]]: start_list[cycle_comp_num[0]] + Q_seg]
+        QcDiff = [a_i - b_i for a_i, b_i in zip(Qc100_1, Qc10_1)]
+        QcDiff = [elem for elem in QcDiff if (math.isnan(elem) == False)]
+
+        X[0] = np.log10(np.absolute(np.var(QcDiff)))
+        labels.append("abs_variance_discharge_capacity_difference_cycles_2:100")
+
+        X[1] = np.log10(np.absolute(min(QcDiff)))
+        labels.append("abs_min_discharge_capacity_difference_cycles_2:100")
+
+        X[2] = np.log10(np.absolute(np.mean(QcDiff)))
+        X[3] = np.log10(np.absolute(skew(QcDiff)))
+        X[4] = np.log10(np.absolute(kurtosis(QcDiff, fisher=False, bias=False)))
+        X[5] = np.log10(np.sum(np.absolute(QcDiff)))
+        X[6] = np.log10(np.sum(np.square(QcDiff)))
+
+        # Discharging Capacity features
+        Qd100_1 = diagnostic_interpolated.discharge_capacity[
+                  start_list[cycle_comp_num[1]] + Q_seg + 1: start_list[cycle_comp_num[1]] + 2 * Q_seg]
+        Qd10_1 = diagnostic_interpolated.discharge_capacity[
+                 start_list[cycle_comp_num[0]] + Q_seg + 1: start_list[cycle_comp_num[0]] + 2 * Q_seg]
+        QdDiff = [a_i - b_i for a_i, b_i in zip(Qd100_1, Qd10_1)]
+        QdDiff = [elem for elem in QdDiff if (math.isnan(elem) == False)]
+
+        X[7] = np.log10(np.absolute(np.var(QdDiff)))
+        X[8] = np.log10(np.absolute(min(QdDiff)))
+        X[9] = np.log10(np.absolute(np.mean(QdDiff)))
+        X[10] = np.log10(np.absolute(skew(QdDiff)))
+        X[11] = np.log10(np.absolute(kurtosis(QdDiff, fisher=False, bias=False)))
+        X[12] = np.log10(np.sum(np.absolute(QdDiff)))
+        X[13] = np.log10(np.sum(np.square(QdDiff)))
+
+        # Charging Energy features
+        Ec100_1 = diagnostic_interpolated.charge_energy[
+                  start_list[cycle_comp_num[1]]: start_list[cycle_comp_num[1]] + Q_seg]
+        Ec10_1 = diagnostic_interpolated.charge_energy[
+                 start_list[cycle_comp_num[0]]: start_list[cycle_comp_num[0]] + Q_seg]
+        EcDiff = [a_i - b_i for a_i, b_i in zip(Ec100_1, Ec10_1)]
+        EcDiff = [elem for elem in EcDiff if (math.isnan(elem) == False)]
+
+        X[14] = np.log10(np.absolute(np.var(EcDiff)))
+        X[15] = np.log10(np.absolute(min(EcDiff)))
+        X[16] = np.log10(np.absolute(np.mean(EcDiff)))
+        X[17] = np.log10(np.absolute(skew(EcDiff)))
+        X[18] = np.log10(np.absolute(kurtosis(EcDiff, fisher=False, bias=False)))
+        X[19] = np.log10(np.sum(np.absolute(EcDiff)))
+        X[20] = np.log10(np.sum(np.square(EcDiff)))
+
+        # Discharging Energy features
+        Ed100_1 = diagnostic_interpolated.discharge_energy[
+                  start_list[cycle_comp_num[1]] + Q_seg + 1: start_list[cycle_comp_num[1]] + 2 * Q_seg]
+        Ed10_1 = diagnostic_interpolated.discharge_energy[
+                 start_list[cycle_comp_num[0]] + Q_seg + 1: start_list[cycle_comp_num[0]] + 2 * Q_seg]
+        EdDiff = [a_i - b_i for a_i, b_i in zip(Ed100_1, Ed10_1)]
+        EdDiff = [elem for elem in EdDiff if (math.isnan(elem) == False)]
+
+        X[21] = np.log10(np.absolute(np.var(EdDiff)))
+        X[22] = np.log10(np.absolute(min(EdDiff)))
+        X[23] = np.log10(np.absolute(np.mean(EdDiff)))
+        X[24] = np.log10(np.absolute(skew(EdDiff)))
+        X[25] = np.log10(np.absolute(kurtosis(EdDiff, fisher=False, bias=False)))
+        X[26] = np.log10(np.sum(np.absolute(EdDiff)))
+        X[27] = np.log10(np.sum(np.square(EdDiff)))
+
+        # Charging dQdV features
+        dQdVc100_1 = diagnostic_interpolated.charge_dQdV[
+                     start_list[cycle_comp_num[1]]: start_list[cycle_comp_num[1]] + Q_seg]
+        dQdVc10_1 = diagnostic_interpolated.charge_dQdV[
+                    start_list[cycle_comp_num[0]]: start_list[cycle_comp_num[0]] + Q_seg]
+        dQdVcDiff = [a_i - b_i for a_i, b_i in zip(dQdVc100_1, dQdVc10_1)]
+        dQdVcDiff = [elem for elem in dQdVcDiff if (math.isnan(elem) == False)]
+
+        X[28] = np.log10(np.absolute(np.var(dQdVcDiff)))
+        X[29] = np.log10(np.absolute(min(dQdVcDiff)))
+        X[30] = np.log10(np.absolute(np.mean(dQdVcDiff)))
+        X[31] = np.log10(np.absolute(skew(dQdVcDiff)))
+        X[32] = np.log10(np.absolute(kurtosis(dQdVcDiff, fisher=False, bias=False)))
+        X[33] = np.log10(np.sum(np.absolute(dQdVcDiff)))
+        X[34] = np.log10(np.sum(np.square(dQdVcDiff)))
+
+        # Discharging Capacity features
+        dQdVd100_1 = diagnostic_interpolated.discharge_dQdV[
+                     start_list[cycle_comp_num[1]] + Q_seg + 1: start_list[cycle_comp_num[1]] + 2 * Q_seg]
+        dQdVd10_1 = diagnostic_interpolated.discharge_dQdV[
+                    start_list[cycle_comp_num[0]] + Q_seg + 1: start_list[cycle_comp_num[0]] + 2 * Q_seg]
+        dQdVdDiff = [a_i - b_i for a_i, b_i in zip(dQdVd100_1, dQdVd10_1)]
+        dQdVdDiff = [elem for elem in dQdVdDiff if (math.isnan(elem) == False)]
+
+        X[35] = np.log10(np.absolute(np.var(dQdVdDiff)))
+        X[36] = np.log10(np.absolute(min(dQdVdDiff)))
+        X[37] = np.log10(np.absolute(np.mean(dQdVdDiff)))
+        X[38] = np.log10(np.absolute(skew(dQdVdDiff)))
+        X[39] = np.log10(np.absolute(kurtosis(dQdVdDiff, fisher=False, bias=False)))
+        X[40] = np.log10(np.sum(np.absolute(dQdVdDiff)))
+        X[41] = np.log10(np.sum(np.square(dQdVdDiff)))
+
+        operations = ['var', 'min', 'mean', 'skew', 'kurtosis', 'abs', 'square']
+        quantities = ['charging_capacity', 'discharging_capacity', 'charging_energy', 'discharging_energy',
+                      'charging_dQdV', 'discharging_dQdV']
+
+        X.columns = [y + '_' + x for x in quantities for y in operations]
+        return X
 
 
 class DeltaQFastCharge(BeepFeatures):
@@ -216,7 +560,7 @@ class DeltaQFastCharge(BeepFeatures):
         """
 
         assert cls.mid_pred_cycle > 10  # Sufficient cycles for analysis
-        assert cls.final_pred_cycle > cls.mid_pred_cycle # Must have final_pred_cycle > mid_pred_cycle
+        assert cls.final_pred_cycle > cls.mid_pred_cycle  # Must have final_pred_cycle > mid_pred_cycle
         ifinal = cls.final_pred_cycle - 1  # python indexing
         imid = cls.mid_pred_cycle - 1
         iini = cls.init_pred_cycle - 1
@@ -257,22 +601,22 @@ class DeltaQFastCharge(BeepFeatures):
         Vd = interpolated_df.voltage[interpolated_df.cycle_index == iini]
         Qd_diff = Qd_final.values - Qd_10.values
 
-        X[5] = np.log10(np.abs(np.min(Qd_diff)))   # Minimum
+        X[5] = np.log10(np.abs(np.min(Qd_diff)))  # Minimum
         labels.append("abs_min_discharge_capacity_difference_cycles_2:100")
 
         X[6] = np.log10(np.abs(np.mean(Qd_diff)))  # Mean
         labels.append("abs_mean_discharge_capacity_difference_cycles_2:100")
 
-        X[7] = np.log10(np.abs(np.var(Qd_diff)))   # Variance
+        X[7] = np.log10(np.abs(np.var(Qd_diff)))  # Variance
         labels.append("abs_variance_discharge_capacity_difference_cycles_2:100")
 
-        X[8] = np.log10(np.abs(skew(Qd_diff)))    # Skewness
+        X[8] = np.log10(np.abs(skew(Qd_diff)))  # Skewness
         labels.append("abs_skew_discharge_capacity_difference_cycles_2:100")
 
         X[9] = np.log10(np.abs(kurtosis(Qd_diff)))  # Kurtosis
         labels.append("abs_kurtosis_discharge_capacity_difference_cycles_2:100")
 
-        X[10] = np.log10(np.abs(Qd_diff[0]))       # First difference
+        X[10] = np.log10(np.abs(Qd_diff[0]))  # First difference
         labels.append("abs_first_discharge_capacity_difference_cycles_2:100")
 
         X[11] = max(summary.temperature_maximum[list(range(1, cls.final_pred_cycle))])  # Max T
@@ -335,7 +679,7 @@ class DeltaQFastCharge(BeepFeatures):
             'barcode': processed_cycler_run.barcode,
             'protocol': processed_cycler_run.protocol,
             'channel_id': processed_cycler_run.channel_id
-                }
+        }
         return metadata
 
 
@@ -388,6 +732,7 @@ class DegradationPredictor(MSONable):
         predicted_quantity (str): 'cycle' or 'capacity'.
         nominal_capacity (float):
     """
+
     def __init__(self, name, X, feature_labels=None, y=None, nominal_capacity=1.1,
                  predict_only=False, predicted_quantity="cycle", prediction_type="multi"):
         """
@@ -496,22 +841,22 @@ class DegradationPredictor(MSONable):
         Vd = interpolated_df.voltage[interpolated_df.cycle_index == iini]
         Qd_diff = Qd_final.values - Qd_10.values
 
-        X[5] = np.log10(np.abs(np.min(Qd_diff)))   # Minimum
+        X[5] = np.log10(np.abs(np.min(Qd_diff)))  # Minimum
         labels.append("abs_min_discharge_capacity_difference_cycles_2:100")
 
         X[6] = np.log10(np.abs(np.mean(Qd_diff)))  # Mean
         labels.append("abs_mean_discharge_capacity_difference_cycles_2:100")
 
-        X[7] = np.log10(np.abs(np.var(Qd_diff)))   # Variance
+        X[7] = np.log10(np.abs(np.var(Qd_diff)))  # Variance
         labels.append("abs_variance_discharge_capacity_difference_cycles_2:100")
 
-        X[8] = np.log10(np.abs(skew(Qd_diff)))    # Skewness
+        X[8] = np.log10(np.abs(skew(Qd_diff)))  # Skewness
         labels.append("abs_skew_discharge_capacity_difference_cycles_2:100")
 
         X[9] = np.log10(np.abs(kurtosis(Qd_diff)))  # Kurtosis
         labels.append("abs_kurtosis_discharge_capacity_difference_cycles_2:100")
 
-        X[10] = np.log10(np.abs(Qd_diff[0]))       # First difference
+        X[10] = np.log10(np.abs(Qd_diff[0]))  # First difference
         labels.append("abs_first_discharge_capacity_difference_cycles_2:100")
 
         X[11] = max(summary.temperature_maximum[list(range(1, final_pred_cycle))])  # Max T
@@ -587,7 +932,7 @@ class DegradationPredictor(MSONable):
                "feature_labels": self.feature_labels,
                "predict_only": self.predict_only,
                "prediction_type": self.prediction_type,
-               "nominal_capacity":self.nominal_capacity
+               "nominal_capacity": self.nominal_capacity
                }
         if isinstance(self.y, pd.DataFrame):
             obj["y"] = self.y.to_dict("list")
@@ -677,7 +1022,7 @@ def process_file_list_from_json(file_list_json, processed_dir='data-share/featur
                 processed_result_list.append("success")
                 processed_message_list.append({'comment': '',
                                                'error': ''})
-                logger.info('Successfully generated %s',  featurizer.name, extra=s)
+                logger.info('Successfully generated %s', featurizer.name, extra=s)
             else:
                 processed_paths_list.append(path)
                 processed_run_list.append(run_id)

--- a/beep/helpers/featurizer_helpers.py
+++ b/beep/helpers/featurizer_helpers.py
@@ -407,12 +407,11 @@ def get_V_I(df):
     return result
 
 
-def get_v_diff(file, diag_num, processed_cycler_run, soc_window):
+def get_v_diff(diag_num, processed_cycler_run, soc_window):
     """
     This function helps us get the feature of the variance of the voltage difference
     across a specific capacity window
     Argument:
-            file(str): a string that has the filename
             diag_num(int): diagnostic cycle number at which you want to get the feature, such as 37 or 142
             processed_cycler_run(process_cycler_run object)
             soc_window(int): let the function know which step_counter_index you want to look at
@@ -431,7 +430,7 @@ def get_v_diff(file, diag_num, processed_cycler_run, soc_window):
     step_counters_1 = hppc_data_1_d.step_index_counter.unique()
     step_counters_2 = hppc_data_2_d.step_index_counter.unique()
     if (len(step_counters_1) < 8) or (len(step_counters_2) < 8):
-        print('error' + file)
+        print('error')
         return None
     else:
         chosen_1 = hppc_data_1_d.loc[hppc_data_1_d.step_index_counter == step_counters_1[soc_window]]
@@ -439,35 +438,17 @@ def get_v_diff(file, diag_num, processed_cycler_run, soc_window):
         chosen_1 = chosen_1.loc[chosen_1.discharge_capacity.notna()]
         chosen_2 = chosen_2.loc[chosen_2.discharge_capacity.notna()]
         if len(chosen_1) == 0 or len(chosen_2) == 0:
-            print('error' + file)
+            print('error')
             return None
         f = interp(chosen_2)
         v_1 = chosen_1.voltage.tolist()
         v_2 = f(chosen_1.discharge_capacity).tolist()
         v_diff = list_minus(v_1, v_2)
         if abs(np.var(v_diff)) > 1:
-            print('weird voltage' + file)
+            print('weird voltage')
             return None
         else:
             return v_diff
-
-
-def get_cutoff_voltage(file, df_cat):
-    """
-    this function can help us get the cycling parameters, that is cut-off voltages for
-    both charge and dishcharge for a given filename
-    Argument:
-            file, the filename for the cell
-            df_cat, a dataframe that contains all the cycling parameters
-    Returns:
-            charge and discharge cut_off voltages in the format of categorical variables
-    """
-    seq_num = int(file[11:14])
-    chosen = df_cat.loc[df_cat['seq_num'] == seq_num]
-    result = pd.DataFrame()
-    result['charge_cutoff_voltage'] = chosen['charge_cutoff_voltage']
-    result['discharge_cutoff_voltage'] = chosen['discharge_cutoff_voltage']
-    return result
 
 
 def get_energy_fraction(diag_num, processed_cycler_run, remaining, metric, cycle_type, file):

--- a/beep/helpers/featurizer_helpers.py
+++ b/beep/helpers/featurizer_helpers.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+#  Copyright (c) 2019 Toyota Research Institute
+
+"""
+Helper functions for generating features in beep.featurize module
+All methods are currently lumped into this script.
+"""
+
+
+import pandas as pd
+import numpy as np
+import matplotlib as plt
+from scipy import optimize, signal
+from lmfit import models
+from scipy.interpolate import interp1d
+
+
+def isolate_dQdV_peaks(processed_cycler_run, diag_nr, charge_y_n, max_nr_peaks, rpt_type, half_peak_width=0.075):
+    """
+    Determine the number of cycles to reach a certain level of degradation
+
+    Args:
+        processed_cycler_run: processed_cycler_run (beep.structure.ProcessedCyclerRun): information about cycler run
+        rpt_type: string indicating which rpt to pick
+        charge_y_n: if 1 (default), takes charge dQdV, if 0, takes discharge dQdV
+        diag_nr: if 1 (default), takes dQdV of 1st RPT past the initial diagnostic
+
+    Returns:
+        dataframe with Voltage and dQdV columns for charge or discharge curve in the rpt_type diagnostic cycle.
+        The peaks will be isolated
+    """
+
+    rpt_type_data = processed_cycler_run.diagnostic_interpolated[(processed_cycler_run.diagnostic_interpolated.cycle_type == rpt_type)]
+    cycles = rpt_type_data.cycle_index.unique()
+
+    ## Take charge or discharge from cycle 'diag_nr'
+    data = pd.DataFrame({'dQdV': [], 'voltage': []})
+
+    if charge_y_n == 1:
+        data.dQdV = rpt_type_data[
+            (rpt_type_data.cycle_index == cycles[diag_nr]) & (rpt_type_data.step_type == 0)].charge_dQdV.values
+        data.voltage = rpt_type_data[
+            (rpt_type_data.cycle_index == cycles[diag_nr]) & (rpt_type_data.step_type == 0)].voltage.values
+    elif charge_y_n == 0:
+        data.dQdV = rpt_type_data[
+            (rpt_type_data.cycle_index == cycles[diag_nr]) & (rpt_type_data.step_type == 1)].discharge_dQdV.values
+        data.voltage = rpt_type_data[
+            (rpt_type_data.cycle_index == cycles[diag_nr]) & (rpt_type_data.step_type == 1)].voltage.values
+        # Turn values to positive temporarily
+        data.dQdV = -data.dQdV
+    else:
+        raise NotImplementedError('Charge_y_n must be either 0 or 1')
+
+    # Remove NaN from x and y
+    data = data.dropna()
+
+    # Reset x and y to values without NaNs
+    x = data.voltage
+    y = data.dQdV
+
+    # Remove strong outliers
+    upper_limit = y.sort_values().tail(round(0.01 * len(y))).mean() + y.sort_values().mean()
+    data = data[(y < upper_limit)]
+
+    # Reset x and y to values without outliers
+    x = data.voltage
+    y = data.dQdV
+
+    # Filter out the x values of the peaks only
+    no_filter_data = data
+
+    # Find peaks
+    peak_indices = signal.find_peaks_cwt(y, (10,))[-max_nr_peaks:]
+
+    peak_voltages = {}
+    peak_dQdVs = {}
+
+    for count, i in enumerate(peak_indices):
+        temp_filter_data = no_filter_data[((x > x.iloc[i] - half_peak_width) & (x < x.iloc[i] + half_peak_width))]
+        peak_voltages[count] = x.iloc[i]
+        peak_dQdVs[count] = y.iloc[i]
+
+        if count == 0:
+            filter_data = temp_filter_data
+        else:
+            filter_data = filter_data.append(temp_filter_data)
+
+    return filter_data, no_filter_data, peak_voltages, peak_dQdVs
+
+
+def generate_model(spec):
+    """
+    Method that generates a model to fit the hppc data to for peak extraction, using spec dictionary
+    :param spec (dict): dictionary containing X, y model types.
+    :return: composite model objects of lmfit Model class and a parameter object as defined in lmfit.
+    """
+    composite_model = None
+    params = None
+    x = spec['x']
+    y = spec['y']
+    x_min = np.min(x)
+    x_max = np.max(x)
+    x_range = x_max - x_min
+    y_max = np.max(y)
+    for i, basis_func in enumerate(spec['model']):
+        prefix = f'm{i}_'
+
+        #models is an lmfit object
+        model = getattr(models, basis_func['type'])(prefix=prefix)
+        if basis_func['type'] in ['GaussianModel', 'LorentzianModel',
+                                  'VoigtModel']:  # for now VoigtModel has gamma constrained to sigma
+            model.set_param_hint('sigma', min=1e-6, max=x_range)
+            model.set_param_hint('center', min=x_min, max=x_max)
+            model.set_param_hint('height', min=1e-6, max=1.1 * y_max)
+            model.set_param_hint('amplitude', min=1e-6)
+
+            default_params = {
+                prefix + 'center': x_min + x_range * np.random.randn(),
+                prefix + 'height': y_max * np.random.randn(),
+                prefix + 'sigma': x_range * np.random.randn()
+            }
+        else:
+            raise NotImplemented(f'model {basis_func["type"]} not implemented yet')
+        if 'help' in basis_func:  # allow override of settings in parameter
+            for param, options in basis_func['help'].items():
+                model.set_param_hint(param, **options)
+        model_params = model.make_params(**default_params, **basis_func.get('params', {}))
+        if params is None:
+            params = model_params
+        else:
+            params.update(model_params)
+        if composite_model is None:
+            composite_model = model
+        else:
+            composite_model = composite_model + model
+    return composite_model, params
+
+
+def update_spec_from_peaks(spec, model_indices, peak_voltages, peak_dQdVs, peak_widths=(10,), **kwargs):
+    x = spec['x']
+    y = spec['y']
+    x_range = np.max(x) - np.min(x)
+
+    for i, j, model_index in zip(peak_voltages, peak_dQdVs, model_indices):
+        model = spec['model'][model_index]
+
+        if model['type'] in ['GaussianModel', 'LorentzianModel', 'VoigtModel']:
+            params = {
+                'height': peak_dQdVs[j],
+                'sigma': x_range / len(x) * np.min(peak_widths),
+                'center': peak_voltages[i]
+            }
+            if 'params' in model:
+                model.update(params)
+            else:
+                model['params'] = params
+        else:
+            raise NotImplemented(f'model {basis_func["type"]} not implemented yet')
+    return
+
+
+def generate_dQdV_peak_fits(processed_cycler_run, rpt_type, diag_nr, charge_y_n, plotting_y_n=0, max_nr_peaks=4):
+    """
+    Generate fits characteristics from dQdV peaks
+
+    Args:
+        processed_cycler_run: processed_cycler_run (beep.structure.ProcessedCyclerRun)
+        diag_nr: if 1, takes dQdV of 1st RPT past the initial diagnostic, 0 (default) is initial dianostic
+        charge_y_n: if 1 (default), takes charge dQdV, if 0, takes discharge dQdV
+
+
+    Returns:
+        dataframe with Amplitude, mu and sigma of fitted peaks
+    """
+    # Uses isolate_dQdV_peaks function to filter out peaks and returns x(Volt) and y(dQdV) values from peaks
+
+    data, no_filter_data, peak_voltages, peak_dQdVs = isolate_dQdV_peaks(processed_cycler_run, rpt_type=rpt_type, \
+                                                                         charge_y_n=charge_y_n, diag_nr=diag_nr,
+                                                                         max_nr_peaks=max_nr_peaks,
+                                                                         half_peak_width=0.07)
+
+    no_filter_x = no_filter_data.voltage
+    no_filter_y = no_filter_data.dQdV
+
+    ####### Setting spec for gaussian model generation
+
+    x = data.voltage
+    y = data.dQdV
+
+    # Set construct spec using number of peaks
+    model_types = []
+    for i in np.arange(max_nr_peaks):
+        model_types.append({'type': 'GaussianModel', 'help': {'sigma': {'max': 0.1}}})
+
+    spec = {
+        'x': x,
+        'y': y,
+        'model': model_types
+    }
+
+    # Update spec using the found peaks
+    update_spec_from_peaks(spec, np.arange(max_nr_peaks), peak_voltages, peak_dQdVs)
+    if plotting_y_n:
+        fig, ax = plt.subplots()
+        ax.scatter(spec['x'], spec['y'], s=4)
+        for i in peak_voltages:
+            ax.axvline(x=peak_voltages[i], c='black', linestyle='dotted')
+            ax.scatter(peak_voltages[i], peak_dQdVs[i], s=30, c='red')
+
+    #### Generate fitting model
+
+    model, params = generate_model(spec)
+    output = model.fit(spec['y'], params, x=spec['x'])
+    if plotting_y_n:
+        #         #Plot residuals
+        #         fig, gridspec = output.plot(data_kws={'markersize': 1})
+
+        ### Plot components
+
+        ax.scatter(no_filter_x, no_filter_y, s=4)
+        ax.set_xlabel('Voltage')
+
+        if charge_y_n:
+            ax.set_title(f'dQdV for charge diag cycle {diag_nr}')
+            ax.set_ylabel('dQdV')
+        else:
+            ax.set_title(f'dQdV for discharge diag cycle {diag_nr}')
+            ax.set_ylabel('- dQdV')
+
+        components = output.eval_components()
+        for i, model in enumerate(spec['model']):
+            ax.plot(spec['x'], components[f'm{i}_'])
+
+    # Construct dictionary of peak fits
+    peak_fit_dict = {}
+    for i, model in enumerate(spec['model']):
+        best_values = output.best_values
+        prefix = f'm{i}_'
+        peak_fit_dict[prefix + "Amp"] = [peak_dQdVs[i]]
+        peak_fit_dict[prefix + "Mu"] = [best_values[prefix + "center"]]
+        peak_fit_dict[prefix + "Sig"] = [best_values[prefix + "sigma"]]
+
+    # Make dataframe out of dict
+    peak_fit_df = pd.DataFrame(peak_fit_dict)
+
+    return peak_fit_df
+
+
+
+def interp(df):
+    '''
+    this function takes in a data frame that we are interested in, and
+    returns an interpolation function based on the discharge volatge and capacity
+    '''
+    V = df.voltage.values
+    Q = df.discharge_capacity.values
+    f = interp1d(Q, V, kind='cubic', fill_value="extrapolate")
+    return f
+
+
+def list_minus(list1, list2):
+    """
+    this function takes in two lists and will return a list containing
+    the values of list1 minus list2
+    """
+    result = []
+    zip_object = zip(list1, list2)
+    for list1_i, list2_i in zip_object:
+        result.append(list1_i - list2_i)
+    return result
+
+
+def get_hppc_ocv_helper(cycle_hppc_0, step_num):
+    """
+    this helper function takes in a cycle and a step number
+    and returns a list that stores the mean of the last five points of voltage in different
+    step counter indexes (which is basically the soc window)
+    """
+    chosen1 = cycle_hppc_0[cycle_hppc_0.step_index == step_num]
+    voltage1 = []
+    step_index_counters = chosen1.step_index_counter.unique()[0:9]
+    for i in range(len(step_index_counters)):
+        df_i = chosen1.loc[chosen1.step_index_counter == step_index_counters[i]]
+        voltage1.append(df_i['voltage'].iloc[-10].mean())  # take the mean of the last 10 points of the voltage value
+    return voltage1
+
+
+def get_hppc_ocv(processed_cycler_run, diag_num):
+    '''
+    This function takes in cycling data for one cell and returns the variance of OCVs at different SOCs
+    diag_num cyce minus first hppc cycle(cycle 2)
+    Argument:
+            processed_cycler_run(process_cycler_run object)
+            diag_num(int): diagnostic cycle number at which you want to get the feature, such as 37 or 142
+    Returns:
+            a float
+            the variance of the diag_num minus cycle 2 for OCV
+    '''
+    data = processed_cycler_run.diagnostic_interpolated
+    cycle_hppc = data.loc[data.cycle_type == 'hppc']
+    cycle_hppc = cycle_hppc.loc[cycle_hppc.current.notna()]
+    step = 11
+    step_later = 43
+    cycle_hppc_0 = cycle_hppc.loc[cycle_hppc.cycle_index == 2]
+    #     in case that cycle 2 correspond to two cycles one is real cycle 2, one is at the end
+    cycle_hppc_0 = cycle_hppc_0.loc[cycle_hppc_0.test_time < 250000]
+    voltage_1 = get_hppc_ocv_helper(cycle_hppc_0, step)
+    chosen = cycle_hppc.loc[cycle_hppc.cycle_index == diag_num]
+    voltage_2 = get_hppc_ocv_helper(chosen, step_later)
+    dv = list_minus(voltage_1, voltage_2)
+    return np.var(dv)
+
+
+def get_hppc_r(processed_cycler_run, diag_num):
+    '''
+    This function takes in cycling data for one cell and returns the resistance at different SOCs with resistance at the
+    first hppc cycle(cycle 2) deducted
+    Argument:
+            processed_cycler_run(process_cycler_run object)
+            diag_num(int): diagnostic cycle number at which you want to get the feature, such as 37 or 142
+    Returns:
+            two floats
+            the variance of the diag_num - cycle 2 for HPPC resistance for both charge and discharge
+    '''
+    data = processed_cycler_run.diagnostic_interpolated
+    cycle_hppc = data.loc[data.cycle_type == 'hppc']
+    cycle_hppc = cycle_hppc.loc[cycle_hppc.current.notna()]
+    cycles = cycle_hppc.cycle_index.unique()
+    if diag_num not in cycles:
+        return None
+    steps = [11, 12, 14]
+    states = ['R', 'D', 'C']
+    results_0 = {}
+    results = {}
+    resistance = {}
+    dr_d = {}
+    cycle_hppc_0 = cycle_hppc.loc[cycle_hppc.cycle_index == 2]
+    #     in case that cycle 2 correspond to two cycles one is real cycle 2, one is at the end
+    cycle_hppc_0 = cycle_hppc_0.loc[cycle_hppc_0.test_time < 250000]
+    for i in range(len(steps)):
+        chosen = cycle_hppc_0[cycle_hppc_0.step_index == steps[i]]
+        state = states[i]
+        result = get_V_I(chosen)
+        results_0[state] = result
+    results[2] = results_0
+    steps_later = [43, 44, 46]
+    #     step 43 is rest, 44 is discharge and 46 is charge, use the get ocv function to get the voltage values
+    #     and calculate the over potential and thus the resistance change
+    for i in range(1, len(cycles)):
+        chosen = cycle_hppc[cycle_hppc.cycle_index == cycles[i]]
+        results_s = {}
+        for j in range(len(steps_later)):
+            chosen_s = chosen[chosen.step_index == steps_later[j]]
+            state = states[j]
+            results_s[state] = get_V_I(chosen_s)
+        results[cycles[i]] = results_s
+    # calculate the resistance and compare the cycle evolution
+    keys = list(results.keys())
+    resistance['D'] = {}
+    resistance['C'] = {}
+    for i in range(len(keys)):
+        d_v = results[keys[i]]['D']['voltage']  # discharge voltage for a cycle
+        c_v = results[keys[i]]['C']['voltage']  # charge voltage for a cycle
+        r_v = results[keys[i]]['R']['voltage']  # rest voltage for a cycle
+        r_v_d = r_v[0:min(len(r_v), len(d_v))]  # in case the size is different
+        d_v = d_v[0:min(len(r_v), len(d_v))]
+        c_v = c_v[0:min(len(r_v), len(c_v))]
+        r_v_c = r_v[0:min(len(r_v), len(c_v))]
+        d_n = list(np.array(d_v) - np.array(r_v_d))  # discharge overpotential
+        c_n = list(np.array(c_v) - np.array(r_v_c))  # charge overpotential
+        resistance['D'][keys[i]] = np.true_divide(d_n, results[keys[i]]['D']['current'])
+        resistance['C'][keys[i]] = np.true_divide(c_n, results[keys[i]]['C']['current'])
+    resistance_d = resistance['D']
+    resistance_c = resistance['C']
+    dr_c = {}
+    SOC = list(range(10, 100, 10))
+    for i in range(1, len(keys)):
+        resistance_d_i = resistance_d[keys[i]]
+        resistance_d_0 = resistance_d[keys[0]]
+        resistance_d_0 = resistance_d_0[0:min(len(resistance_d_i), len(resistance_d_0))]
+        dr_d[keys[i]] = list(resistance_d_i - resistance_d_0)
+    for i in range(1, len(keys)):
+        resistance_c_i = resistance_c[keys[i]]
+        resistance_c_0 = resistance_c[keys[0]]
+        resistance_c_0 = resistance_c_0[0:min(len(resistance_c_i), len(resistance_c_0))]
+        dr_c[keys[i]] = list(resistance_c_i - resistance_c_0)
+    f2_d = np.var(dr_d[diag_num])
+    f2_c = np.var(dr_c[diag_num])
+    return f2_d, f2_c
+
+
+def get_V_I(df):
+    """
+    this helper functiion takes in a specific step in the first hppc cycle and gives you the voltage values as
+    well as the current values after each step in the first cycle.
+    """
+    result = {}
+    voltage = []
+    current = []
+    step_index_counters = df.step_index_counter.unique()[0:9]
+    for i in range(len(step_index_counters)):
+        df_i = df.loc[df.step_index_counter == step_index_counters[i]]
+        voltage.append(df_i['voltage'].iloc[-1])  # the last point of the voltage value
+        current.append(df_i['current'].mean())
+    result['voltage'] = voltage
+    result['current'] = current
+    return result
+
+
+def get_v_diff(file, diag_num, processed_cycler_run, soc_window):
+    """
+    This function helps us get the feature of the variance of the voltage difference
+    across a specific capacity window
+    Argument:
+            file(str): a string that has the filename
+            diag_num(int): diagnostic cycle number at which you want to get the feature, such as 37 or 142
+            processed_cycler_run(process_cycler_run object)
+            soc_window(int): let the function know which step_counter_index you want to look at
+    Returns:
+            a float
+    """
+    data = processed_cycler_run.diagnostic_interpolated
+    hppc_data = data.loc[data.cycle_type == 'hppc']
+    # the discharge steps in the hppc cycles step number 47
+    hppc_data_2 = hppc_data.loc[hppc_data.cycle_index == diag_num]
+    hppc_data_1 = hppc_data.loc[hppc_data.cycle_index == 2]
+    #     in case a final HPPC is appended in the end also with cycle number 2
+    hppc_data_1 = hppc_data_1.loc[hppc_data_1.discharge_capacity < 8]
+    hppc_data_2_d = hppc_data_2.loc[hppc_data_2.step_index == 47]
+    hppc_data_1_d = hppc_data_1.loc[hppc_data_1.step_index == 15]
+    step_counters_1 = hppc_data_1_d.step_index_counter.unique()
+    step_counters_2 = hppc_data_2_d.step_index_counter.unique()
+    if (len(step_counters_1) < 8) or (len(step_counters_2) < 8):
+        print('error' + file)
+        return None
+    else:
+        chosen_1 = hppc_data_1_d.loc[hppc_data_1_d.step_index_counter == step_counters_1[soc_window]]
+        chosen_2 = hppc_data_2_d.loc[hppc_data_2_d.step_index_counter == step_counters_2[soc_window]]
+        chosen_1 = chosen_1.loc[chosen_1.discharge_capacity.notna()]
+        chosen_2 = chosen_2.loc[chosen_2.discharge_capacity.notna()]
+        if len(chosen_1) == 0 or len(chosen_2) == 0:
+            print('error' + file)
+            return None
+        f = interp(chosen_2)
+        v_1 = chosen_1.voltage.tolist()
+        v_2 = f(chosen_1.discharge_capacity).tolist()
+        v_diff = list_minus(v_1, v_2)
+        if abs(np.var(v_diff)) > 1:
+            print('weird voltage' + file)
+            return None
+        else:
+            return v_diff
+
+
+def get_cutoff_voltage(file, df_cat):
+    """
+    this function can help us get the cycling parameters, that is cut-off voltages for
+    both charge and dishcharge for a given filename
+    Argument:
+            file, the filename for the cell
+            df_cat, a dataframe that contains all the cycling parameters
+    Returns:
+            charge and discharge cut_off voltages in the format of categorical variables
+    """
+    seq_num = int(file[11:14])
+    chosen = df_cat.loc[df_cat['seq_num'] == seq_num]
+    result = pd.DataFrame()
+    result['charge_cutoff_voltage'] = chosen['charge_cutoff_voltage']
+    result['discharge_cutoff_voltage'] = chosen['discharge_cutoff_voltage']
+    return result
+
+
+def get_energy_fraction(diag_num, processed_cycler_run, remaining, metric, cycle_type, file):
+    """
+    This function can help us to get the dataframe that contains the diagnostic cycle index and energy fraction
+    which we can use to predict energy fraction later
+    Argument:
+            diag_num(int): diagnostic cycle number at which you want to get the feature, such as 37 or 142
+            processed_cycler_run(process_cycler_run object)
+            remaining(float): how much enegry left, such as 0.95
+            metric: such as discharge_energy
+            cycle_type: such as rpt_0.2C
+            file(str): a string that has the filename
+    Returns:
+            a dataframe that contains two columns cycle index and discharge energy fraction
+            Diagnostic cycles after the diagnostic cycle at which we generate the feature
+    """
+    summary_diag = processed_cycler_run.diagnostic_summary[processed_cycler_run.diagnostic_summary.cycle_type == cycle_type]
+    initial = summary_diag[metric].max()
+    threshold = remaining * initial
+    if summary_diag[metric].min() > threshold:
+        print('havent degraded to' + str(remaining) + metric + file)
+        return None
+    y = summary_diag[summary_diag[metric] < threshold].cycle_index.min()
+    if diag_num > y:
+        print('degraded before diagnostic cycle' + str(diag_num) + file)
+        return None
+    df = summary_diag[summary_diag['cycle_index'] > diag_num + 1]
+    result = pd.DataFrame()
+    result['cycle_index'] = df['cycle_index']
+    result['discharge_energy_fraction'] = df['discharge_energy'] / initial
+    return result

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -21,6 +21,8 @@ TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
 PROCESSED_CYCLER_FILE = "2017-06-30_2C-10per_6C_CH10_structure.json"
 PROCESSED_CYCLER_FILE_INSUF = "structure_insufficient.json"
 MACCOR_FILE_W_DIAGNOSTICS = os.path.join(TEST_FILE_DIR, "xTESLADIAG_000020_CH71.071")
+MACCOR_FILE_W_PARAMETERS = os.path.join(TEST_FILE_DIR, 'PredictionDiagnostics_000109_tztest.010')
+
 BIG_FILE_TESTS = os.environ.get("BEEP_BIG_TESTS", False)
 SKIP_MSG = "Tests requiring large files with diagnostic cycles are disabled, set BIG_FILE_TESTS to run full tests"
 
@@ -177,15 +179,13 @@ class TestFeaturizer(unittest.TestCase):
     def test_DiagnosticCyclesFeatures_class(self):
         with ScratchDir('.'):
             os.environ['BEEP_ROOT'] = TEST_FILE_DIR
-            pcycler_run_loc = os.path.join(TEST_FILE_DIR, 'PreDiag_000240_000227_structure.json')
+            pcycler_run_loc = os.path.join(TEST_FILE_DIR, 'PreDiag_000240_000227_truncated_structure.json')
             pcycler_run = loadfn(pcycler_run_loc)
             featurizer = DiagnosticCyclesFeatures.from_run(pcycler_run_loc, os.getcwd(), pcycler_run)
             path, local_filename = os.path.split(featurizer.name)
             folder = os.path.split(path)[-1]
-            self.assertEqual(local_filename,
-                             'PreDiag_000240_000227_features_DiagnosticCyclesFeatures.json')
-            self.assertEqual(folder, 'DiagnosticCyclesFeatures')
             dumpfn(featurizer, featurizer.name)
+            self.assertEqual(folder, 'DiagnosticCyclesFeatures')
             self.assertEqual(featurizer.X.shape[1], 60)
             self.assertTrue(all(x in featurizer.X.columns for x in ['m0_Mu','var(ocv)','var_charging_dQdV'])
 

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -12,7 +12,7 @@ from botocore.exceptions import NoRegionError, NoCredentialsError
 
 from beep.structure import RawCyclerRun, ProcessedCyclerRun
 from beep.featurize import process_file_list_from_json, \
-    DeltaQFastCharge, TrajectoryFastCharge, DegradationPredictor
+    DeltaQFastCharge, TrajectoryFastCharge, DegradationPredictor, DiagnosticCyclesFeatures
 from monty.serialization import dumpfn, loadfn
 from monty.tempfile import ScratchDir
 
@@ -173,3 +173,20 @@ class TestFeaturizer(unittest.TestCase):
             self.assertEqual(output_obj['result_list'][0], 'incomplete')
             self.assertEqual(output_obj['message_list'][0]['comment'],
                              'Insufficient or incorrect data for featurization')
+
+    def test_DiagnosticCyclesFeatures_class(self):
+        with ScratchDir('.'):
+            os.environ['BEEP_ROOT'] = os.getcwd()
+            pcycler_run_loc = os.path.join(TEST_FILE_DIR, 'PreDiag_000240_000227_structure.json')
+            pcycler_run = loadfn(pcycler_run_loc)
+            featurizer = DiagnosticCyclesFeatures.from_run(pcycler_run_loc, os.getcwd(), pcycler_run)
+            path, local_filename = os.path.split(featurizer.name)
+            folder = os.path.split(path)[-1]
+            self.assertEqual(local_filename,
+                             'PreDiag_000240_000227_features_DiagnosticCyclesFeatures.json')
+            self.assertEqual(folder, 'DiagnosticCyclesFeatures')
+            dumpfn(featurizer, featurizer.name)
+            self.assertEqual(featurizer.X.shape[1], 60)
+            self.assertTrue(all(x in featurizer.X.columns for x in ['m0_Mu','var(ocv)','var_charging_dQdV'])
+
+)

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -176,7 +176,7 @@ class TestFeaturizer(unittest.TestCase):
 
     def test_DiagnosticCyclesFeatures_class(self):
         with ScratchDir('.'):
-            os.environ['BEEP_ROOT'] = os.getcwd()
+            os.environ['BEEP_ROOT'] = TEST_FILE_DIR
             pcycler_run_loc = os.path.join(TEST_FILE_DIR, 'PreDiag_000240_000227_structure.json')
             pcycler_run = loadfn(pcycler_run_loc)
             featurizer = DiagnosticCyclesFeatures.from_run(pcycler_run_loc, os.getcwd(), pcycler_run)

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ setup(name="beep",
                         "msgpack-python==0.5.6",
                         "python-dateutil==2.8.0",
                         "xmltodict==0.12.0",
-                        "tables==3.6.1"
+                        "tables==3.6.1",
+                        "lmfit==1.0.1"
                         ],
       extras_require={
           "tests": ["pytest",


### PR DESCRIPTION
Initial PR for adding diagnostic cycles based features in the new featurization framework.
- All relevant helper functions for generating the feature object are dumped in /helpers/featurizer_helpers.py. We can discuss grouping them into classes of helpers, in support of the respective featurizer. 
- I did quite a bit of clean-up of the code, but considerable refactor of code is still necessary for consistency in variable names, docstrings and assertions need to be added. 