### PR TITLE
Add data types to arbin

### DIFF
--- a/beep/conversion_schemas/arbin_conversion.yaml
+++ b/beep/conversion_schemas/arbin_conversion.yaml
@@ -21,7 +21,7 @@ metadata_fields:
   value: _value
   value2: _value2
 data_columns:
-  data_point: _data_point
+  data_point: data_point
   test_time: test_time
   datetime: date_time
   step_time: step_time
@@ -35,7 +35,7 @@ data_columns:
   discharge_energy: discharge_energy
   dv/dt: _dv/dt
   internal_resistance: internal_resistance
-  Temperature: temperature
+  temperature: temperature
 data_types:
   data_point: 'int32'
   test_time: 'float32'

--- a/beep/conversion_schemas/arbin_conversion.yaml
+++ b/beep/conversion_schemas/arbin_conversion.yaml
@@ -36,3 +36,19 @@ data_columns:
   dv/dt: _dv/dt
   internal_resistance: internal_resistance
   Temperature: temperature
+data_types:
+  data_point: 'int32'
+  test_time: 'float32'
+  datetime: 'float32'
+  step_time: 'float32'
+  step_index: 'int16'
+  cycle_index: 'int32'
+  current: 'float32'
+  voltage: 'float32'
+  charge_capacity: 'float64'
+  discharge_capacity: 'float64'
+  charge_energy: 'float64'
+  discharge_energy: 'float64'
+  dv/dt: 'float32'
+  internal_resistance: 'float32'
+  temperature: 'float32'

--- a/beep/structure.py
+++ b/beep/structure.py
@@ -532,7 +532,7 @@ class RawCyclerRun(MSONable):
         for column, dtype in ARBIN_CONFIG['data_types'].items():
             if column in data:
                 if not data[column].isnull().values.any():
-                    data[column] = pd.Series(data[column], dtype=dtype)
+                    data[column] = data[column].astype(dtype)
 
         data.rename(ARBIN_CONFIG['data_columns'], axis='columns', inplace=True)
         metadata = pd.read_csv(metadata_path)

--- a/beep/structure.py
+++ b/beep/structure.py
@@ -527,6 +527,7 @@ class RawCyclerRun(MSONable):
         metadata_path = path.replace(".csv", "_Metadata.csv")
         data = pd.read_csv(path)
         data.rename(str.lower, axis='columns', inplace=True)
+        data = data.astype(ARBIN_CONFIG['data_types'])
         data.rename(ARBIN_CONFIG['data_columns'], axis='columns', inplace=True)
         metadata = pd.read_csv(metadata_path)
         metadata.rename(str.lower, axis='columns', inplace=True)

--- a/beep/structure.py
+++ b/beep/structure.py
@@ -256,6 +256,7 @@ class RawCyclerRun(MSONable):
         Returns:
             beep.structure.RawCyclerRun:
         """
+
         data = pd.DataFrame(d['data'])
         data = data.sort_index()
         return cls(data, d['metadata'], d['eis'])
@@ -527,7 +528,12 @@ class RawCyclerRun(MSONable):
         metadata_path = path.replace(".csv", "_Metadata.csv")
         data = pd.read_csv(path)
         data.rename(str.lower, axis='columns', inplace=True)
-        data = data.astype(ARBIN_CONFIG['data_types'])
+
+        for column, dtype in ARBIN_CONFIG['data_types'].items():
+            if column in data:
+                if not data[column].isnull().values.any():
+                    data[column] = pd.Series(data[column], dtype=dtype)
+
         data.rename(ARBIN_CONFIG['data_columns'], axis='columns', inplace=True)
         metadata = pd.read_csv(metadata_path)
         metadata.rename(str.lower, axis='columns', inplace=True)

--- a/beep/tests/test_structure.py
+++ b/beep/tests/test_structure.py
@@ -596,11 +596,11 @@ class ProcessedCyclerRunTest(unittest.TestCase):
         self.assertEqual(pcycler_run.protocol, r"2017-12-04_tests\20170630-4_65C_69per_6C.sdu")
 
         all_summary = pcycler_run.summary
-        reg_dyptes = all_summary.dtypes.tolist()
+        reg_dtypes = all_summary.dtypes.tolist()
         reg_columns = all_summary.columns.tolist()
-        reg_dyptes = [str(dtyp) for dtyp in reg_dyptes]
+        reg_dtypes = [str(dtyp) for dtyp in reg_dtypes]
         for indx, col in enumerate(reg_columns):
-            self.assertEqual(reg_dyptes[indx], STRUCTURE_DTYPES['summary'][col])
+            self.assertEqual(reg_dtypes[indx], STRUCTURE_DTYPES['summary'][col])
 
         all_interpolated = pcycler_run.cycles_interpolated
         cycles_interpolated_dyptes = all_interpolated.dtypes.tolist()

--- a/beep/tests/test_structure.py
+++ b/beep/tests/test_structure.py
@@ -46,7 +46,10 @@ class RawCyclerRunTest(unittest.TestCase):
         with ScratchDir('.'):
             dumpfn(smaller_run, "smaller_cycler_run.json")
             resurrected = loadfn("smaller_cycler_run.json")
-        pd.testing.assert_frame_equal(smaller_run.data, resurrected.data, check_dtype=True)
+            self.assertIsInstance(resurrected, RawCyclerRun)
+            self.assertIsInstance(resurrected.data, pd.DataFrame)
+            self.assertEqual(smaller_run.data.voltage.to_list(), resurrected.data.voltage.to_list())
+            self.assertEqual(smaller_run.data.current.to_list(), resurrected.data.current.to_list())
 
     def test_ingestion_maccor(self):
         raw_cycler_run = RawCyclerRun.from_maccor_file(self.maccor_file, include_eis=False)
@@ -591,6 +594,20 @@ class ProcessedCyclerRunTest(unittest.TestCase):
         # Ensure barcode/protocol are passed
         self.assertEqual(pcycler_run.barcode, "EL151000429559")
         self.assertEqual(pcycler_run.protocol, r"2017-12-04_tests\20170630-4_65C_69per_6C.sdu")
+
+        all_summary = pcycler_run.summary
+        reg_dyptes = all_summary.dtypes.tolist()
+        reg_columns = all_summary.columns.tolist()
+        reg_dyptes = [str(dtyp) for dtyp in reg_dyptes]
+        for indx, col in enumerate(reg_columns):
+            self.assertEqual(reg_dyptes[indx], STRUCTURE_DTYPES['summary'][col])
+
+        all_interpolated = pcycler_run.cycles_interpolated
+        cycles_interpolated_dyptes = all_interpolated.dtypes.tolist()
+        cycles_interpolated_columns = all_interpolated.columns.tolist()
+        cycles_interpolated_dyptes = [str(dtyp) for dtyp in cycles_interpolated_dyptes]
+        for indx, col in enumerate(cycles_interpolated_columns):
+            self.assertEqual(cycles_interpolated_dyptes[indx], STRUCTURE_DTYPES['cycles_interpolated'][col])
 
     def test_from_raw_cycler_run_maccor(self):
         rcycler_run = RawCyclerRun.from_file(self.maccor_file_w_diagnostics)


### PR DESCRIPTION
This PR adds data types to the Arbin raw data as an initial attempt to reduce the memory footprint.
- Added section to the arbin schema for data types
- Data types are applied immediately after loading the data into a dataframe