### PR TITLE
Issue 45 change directory creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,23 @@ pip (or `python setup.py develop`)  for an editable install:
 git clone git@github.com:ToyotaResearchInstitute/BEEP.git
 cd BEEP
 pip install -e .
+
+```
+## Environment
+To configure the use of AWS resources its necessary to set the environment variable `BEEP_ENV`. For most users `'dev'`
+is the appropriate choice since it assumes that no AWS resources are available. 
+```.env
+export BEEP_ENV='dev'
+```
+For processing file locally its necessary to configure the folder structure 
+```.env
+export BEEP_ROOT='/path/to/beep/data/'
 ```
 
 ## Testing
 You can use nose or pytests for running unittests (use `pip install nose` 
 to install nose if not installed). In order to run tests the environment variable
-needs to be set (ie. export BEEP_ENV='local')
+needs to be set (ie. export BEEP_ENV='dev')
 
 ```bash
 nosetests beep
@@ -69,7 +80,7 @@ $ collate
 ```
 ```json
 {
-    "mode": "run",
+    "mode": "events_off",
     "fid": [0, 
             1, 
             2],
@@ -113,7 +124,7 @@ The output json will have the following fields:
 Example:
 ```bash
 $ validate '{
-    "mode": "run",
+    "mode": "events_off",
     "run_list": [1, 20, 34],
     "strname": ["2017-05-09_test-TC-contact", 
                 "2017-08-14_8C-5per_3_47C", 
@@ -164,7 +175,7 @@ The output json contains the following fields:
 Example:
 ```bash
 $ structure '{
-    "mode": "run",
+    "mode": "events_off",
     "run_list": [1, 20, 34],
     "validity": ["invalid", "invalid", "valid"], 
     "file_list": ["/data-share/renamed_cycler_files/FastCharge/FastCharge_0_CH33.csv", 
@@ -197,7 +208,7 @@ The output json file will contain the following:
 Example:
 ```bash
 $ featurize '{
-    "mode": "run",
+    "mode": "events_off",
     "run_list": [1, 20, 34],
     "invalid_file_list": ["/data-share/renamed_cycler_files/FastCharge/FastCharge_0_CH33.csv", 
                           "/data-share/renamed_cycler_files/FastCharge/FastCharge_1_CH44.csv"], 
@@ -225,7 +236,7 @@ The output json will contain the following fields
 Example:
 ```bash
 $ run_model '{
-    "mode": "run",
+    "mode": "events_off",
     "run_list": [34],
     "file_list": ["/data-share/features/FastCharge_2_CH29_full_model_features.json"]
 }'

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ export BEEP_ENV='dev'
 ```
 For processing file locally its necessary to configure the folder structure 
 ```.env
-export BEEP_ROOT='/path/to/beep/data/'
+export BEEP_PROCESSING_DIR='/path/to/beep/data/'
 ```
 
 ## Testing
@@ -57,7 +57,7 @@ as input in order to provide flexibility and more facile automation.  They are d
 below:
 
 ### collate
-The `collate` script takes no input, and operates by assuming the BEEP_ROOT (default `/`)
+The `collate` script takes no input, and operates by assuming the BEEP_PROCESSING_DIR (default `/`)
 has subdirectories `/data-share/raw_cycler_files` and `data-share/renamed_cycler_files/FastCharge`.
 
 The script moves files from the `/data-share/raw_cycler_files` directory, parses the metadata,

--- a/beep/__init__.py
+++ b/beep/__init__.py
@@ -32,6 +32,7 @@ if VERSION_TAG is not None:
 tqdm = partial(_tqdm, disable=bool(os.environ.get("TQDM_OFF")))
 
 ENV_VAR = 'BEEP_ENV'
+PROCESSED_DIR = 'BEEP_PROCESSING_DIR'
 MAX_RETRIES = 12
 
 # environment
@@ -40,6 +41,16 @@ if ENVIRONMENT is None or ENVIRONMENT not in config.keys():
     raise ValueError(f'Environment variable {ENV_VAR} must be set and be one '
                      + f'of the following: {", ".join(list(config.keys()))}. '
                      + f'Found: {ENVIRONMENT}')
+
+DIR = os.getenv(PROCESSED_DIR)
+if DIR is None:
+    if ENVIRONMENT in ['stage', 'prod']:
+        os.environ[PROCESSED_DIR] = "/"
+    elif ENVIRONMENT in ['local', 'dev', 'test']:
+        os.environ[PROCESSED_DIR] = os.path.dirname(__file__)
+    else:
+        raise ValueError(f'The directory for processing cycling data {PROCESSED_DIR} must be set'
+                         + f' eg. /Users/Bob/cycling')
 
 MODULE_DIR = os.path.dirname(__file__)
 CONVERSION_SCHEMA_DIR = os.path.join(MODULE_DIR, "conversion_schemas")

--- a/beep/collate.py
+++ b/beep/collate.py
@@ -229,6 +229,10 @@ def process_files_json():
     # chdir into beep root
     pwd = os.getcwd()
     os.chdir(os.environ.get("BEEP_ROOT", "/"))
+    if not os.path.exists(SRC_DIR):
+        os.makedirs(SRC_DIR)
+    if not os.path.exists(DEST_DIR):
+        os.makedirs(DEST_DIR)
 
     meta_list = list(filter(lambda x: '_Metadata.csv' in x, os.listdir(SRC_DIR)))
     file_list = list(filter(lambda x: '.csv' in x if x not in meta_list else None, os.listdir(SRC_DIR)))

--- a/beep/collate.py
+++ b/beep/collate.py
@@ -9,7 +9,7 @@ Options:
     -h --help       Show this screen
     --version       Show version
 
-The `collate` script takes no input, and operates by assuming the BEEP_ROOT (default `/`)
+The `collate` script takes no input, and operates by assuming the BEEP_PROCESSING_DIR (default `/`)
 has subdirectories `/data-share/raw_cycler_files` and `data-share/renamed_cycler_files/FastCharge`.
 
 The script moves files from the `/data-share/raw_cycler_files` directory, parses the metadata,
@@ -218,7 +218,7 @@ def init_map(project_name, destination_directory):
 
 def process_files_json():
     """
-    Inspects the BEEP_ROOT directory and renames
+    Inspects the BEEP_PROCESSING_DIR directory and renames
     files according to the prescribed system of protocol/date/run ID
     associated with the file metadata.  Since this script operates
     only on filesystem assumptions, no input is required.
@@ -228,7 +228,7 @@ def process_files_json():
     """
     # chdir into beep root
     pwd = os.getcwd()
-    os.chdir(os.environ.get("BEEP_ROOT", "/"))
+    os.chdir(os.environ.get("BEEP_PROCESSING_DIR", "/"))
     if not os.path.exists(SRC_DIR):
         os.makedirs(SRC_DIR)
     if not os.path.exists(DEST_DIR):

--- a/beep/featurize.py
+++ b/beep/featurize.py
@@ -985,6 +985,9 @@ def process_file_list_from_json(file_list_json, processed_dir='data-share/featur
     # Add root path to processed_dir
     processed_dir = os.path.join(os.environ.get("BEEP_ROOT", "/"),
                                  processed_dir)
+    if not os.path.exists(processed_dir):
+        os.makedirs(processed_dir)
+
     file_list = file_list_data['file_list']
     run_ids = file_list_data['run_list']
     processed_run_list = []

--- a/beep/featurize.py
+++ b/beep/featurize.py
@@ -983,7 +983,7 @@ def process_file_list_from_json(file_list_json, processed_dir='data-share/featur
     events = KinesisEvents(service='DataAnalyzer', mode=file_list_data['mode'])
 
     # Add root path to processed_dir
-    processed_dir = os.path.join(os.environ.get("BEEP_ROOT", "/"),
+    processed_dir = os.path.join(os.environ.get("BEEP_PROCESSING_DIR", "/"),
                                  processed_dir)
     if not os.path.exists(processed_dir):
         os.makedirs(processed_dir)

--- a/beep/generate_protocol.py
+++ b/beep/generate_protocol.py
@@ -1179,7 +1179,7 @@ def process_csv_file_list_from_json(file_list_json, processed_dir='data-share/pr
 
     file_list = file_list_data['file_list']
     all_output_files = []
-    protocol_dir = os.path.join(os.environ.get("BEEP_ROOT", "/"),
+    protocol_dir = os.path.join(os.environ.get("BEEP_PROCESSING_DIR", "/"),
                               processed_dir)
     for filename in file_list:
         output_files, result, message = generate_protocol_files_from_csv(

--- a/beep/run_model.py
+++ b/beep/run_model.py
@@ -505,6 +505,9 @@ def process_file_list_from_json(file_list_json, model_dir="/data-share/models/",
     # Add BEEP_ROOT to processed_dir
     processed_dir = os.path.join(os.environ.get("BEEP_ROOT", "/"),
                                  processed_dir)
+    if not os.path.exists(processed_dir):
+        os.makedirs(processed_dir)
+
     file_list = file_list_data['file_list']
     run_ids = file_list_data['run_list']
     processed_run_list = []

--- a/beep/run_model.py
+++ b/beep/run_model.py
@@ -502,8 +502,8 @@ def process_file_list_from_json(file_list_json, model_dir="/data-share/models/",
     # Setup Events
     events = KinesisEvents(service='DataAnalyzer', mode=file_list_data['mode'])
 
-    # Add BEEP_ROOT to processed_dir
-    processed_dir = os.path.join(os.environ.get("BEEP_ROOT", "/"),
+    # Add BEEP_PROCESSING_DIR to processed_dir
+    processed_dir = os.path.join(os.environ.get("BEEP_PROCESSING_DIR", "/"),
                                  processed_dir)
     if not os.path.exists(processed_dir):
         os.makedirs(processed_dir)

--- a/beep/structure.py
+++ b/beep/structure.py
@@ -1533,6 +1533,8 @@ def process_file_list_from_json(file_list_json, processed_dir='data-share/struct
 
     # Prepend optional root to output directory
     processed_dir = os.path.join(os.environ.get("BEEP_ROOT", "/"), processed_dir)
+    if not os.path.exists(processed_dir):
+        os.makedirs(processed_dir)
 
     file_list = file_list_data['file_list']
     validities = file_list_data['validity']

--- a/beep/structure.py
+++ b/beep/structure.py
@@ -1358,7 +1358,7 @@ def get_protocol_parameters(filepath, parameters_path='data-share/raw/parameters
     """
     project_name_list = get_project_sequence(filepath)
     project_name = project_name_list[0]
-    path = os.path.join(os.environ.get("BEEP_ROOT", "/"), parameters_path)
+    path = os.path.join(os.environ.get("BEEP_PROCESSING_DIR", "/"), parameters_path)
     project_parameter_files = glob(os.path.join(path, project_name + '*'))
     assert len(project_parameter_files) <= 1, 'Found too many parameter files for: ' + project_name
 
@@ -1532,7 +1532,7 @@ def process_file_list_from_json(file_list_json, processed_dir='data-share/struct
     events = KinesisEvents(service='DataStructurer', mode=file_list_data['mode'])
 
     # Prepend optional root to output directory
-    processed_dir = os.path.join(os.environ.get("BEEP_ROOT", "/"), processed_dir)
+    processed_dir = os.path.join(os.environ.get("BEEP_PROCESSING_DIR", "/"), processed_dir)
     if not os.path.exists(processed_dir):
         os.makedirs(processed_dir)
 

--- a/beep/tests/test_collate.py
+++ b/beep/tests/test_collate.py
@@ -45,7 +45,7 @@ class CollateTest(unittest.TestCase):
             params = get_parameters_fastcharge(filename, source_directory)
 
         with ScratchDir('.'):
-            os.environ["BEEP_ROOT"] = os.getcwd()
+            os.environ["BEEP_PROCESSING_DIR"] = os.getcwd()
             os.mkdir("data-share")
             os.mkdir(os.path.join("data-share", "raw_cycler_files"))
             os.mkdir(os.path.join("data-share", "renamed_cycler_files"))

--- a/beep/tests/test_end_to_end.py
+++ b/beep/tests/test_end_to_end.py
@@ -11,7 +11,6 @@ import pandas as pd
 
 from tempfile import mkdtemp
 from monty.serialization import loadfn
-from botocore.exceptions import NoRegionError, NoCredentialsError
 
 from beep import collate, validate, structure, featurize,\
     run_model, MODEL_DIR
@@ -28,7 +27,7 @@ class EndToEndTest(unittest.TestCase):
             kinesis = boto3.client('kinesis')
             response = kinesis.list_streams()
             self.events_mode = 'test'
-        except NoRegionError or NoCredentialsError as e:
+        except Exception as e:
             self.events_mode = 'events_off'
 
         # Get cwd, create and enter scratch dir
@@ -46,11 +45,6 @@ class EndToEndTest(unittest.TestCase):
 
         # Set up directory structure and specify the test files
         os.mkdir("raw_cycler_files")
-        os.mkdir("renamed_cycler_files")
-        os.mkdir("validation")
-        os.mkdir("structure")
-        os.mkdir("features")
-        os.mkdir("predictions")
 
         # Copy starting files into raw_cycler_files directory
         starting_files = [

--- a/beep/tests/test_end_to_end.py
+++ b/beep/tests/test_end_to_end.py
@@ -1,6 +1,7 @@
 #  Copyright (c) 2019 Toyota Research Institute
 
 import unittest
+import warnings
 import os
 import shutil
 import subprocess
@@ -28,6 +29,7 @@ class EndToEndTest(unittest.TestCase):
             response = kinesis.list_streams()
             self.events_mode = 'test'
         except Exception as e:
+            warnings.warn("Cloud resources not configured")
             self.events_mode = 'events_off'
 
         # Get cwd, create and enter scratch dir
@@ -36,8 +38,8 @@ class EndToEndTest(unittest.TestCase):
         os.chdir(scratch_dir)
         self.scratch_dir = scratch_dir
 
-        # Set BEEP_ROOT directory to scratch_dir
-        os.environ['BEEP_ROOT'] = scratch_dir
+        # Set BEEP_PROCESSING_DIR directory to scratch_dir
+        os.environ['BEEP_PROCESSING_DIR'] = scratch_dir
 
         # Create data-share and subfolders
         os.mkdir("data-share")

--- a/beep/tests/test_events.py
+++ b/beep/tests/test_events.py
@@ -3,6 +3,7 @@
 
 import os
 import unittest
+import warnings
 import datetime
 import pytz
 import numpy as np
@@ -26,6 +27,7 @@ class KinesisEventsTest(unittest.TestCase):
         print(response)
         beep_kinesis_connection_broken = False
     except Exception as e:
+        warnings.warn("Cloud resources not configured")
         beep_kinesis_connection_broken = True
 
     def setUp(self):
@@ -200,6 +202,7 @@ class CloudWatchLoggingTest(unittest.TestCase):
         cloudwatch.describe_alarms()
         beep_cloudwatch_connection_broken = False
     except Exception as e:
+        warnings.warn("Cloud resources not configured")
         beep_cloudwatch_connection_broken = True
 
     def setUp(self):

--- a/beep/tests/test_events.py
+++ b/beep/tests/test_events.py
@@ -8,7 +8,6 @@ import pytz
 import numpy as np
 import boto3
 from dateutil.tz import tzutc
-from botocore.exceptions import NoRegionError, NoCredentialsError
 from beep.utils import KinesisEvents, Logger
 from beep.utils.secrets_manager import get_secret
 from beep.config import config
@@ -26,14 +25,14 @@ class KinesisEventsTest(unittest.TestCase):
         response = kinesis.list_streams()
         print(response)
         beep_kinesis_connection_broken = False
-    except NoRegionError or NoCredentialsError as e:
+    except Exception as e:
         beep_kinesis_connection_broken = True
 
     def setUp(self):
         try:
             stream_name = get_secret(config[ENVIRONMENT]['kinesis']['stream'])['streamName']
             self.assertEqual('kinesis-test', stream_name)
-        except NoRegionError or NoCredentialsError as e:
+        except Exception as e:
             beep_secrets_connection_broken = True
 
     @unittest.skipIf(beep_kinesis_connection_broken, "Unable to connect to Kinesis")
@@ -200,7 +199,7 @@ class CloudWatchLoggingTest(unittest.TestCase):
         cloudwatch = boto3.client('cloudwatch')
         cloudwatch.describe_alarms()
         beep_cloudwatch_connection_broken = False
-    except NoRegionError or NoCredentialsError as e:
+    except Exception as e:
         beep_cloudwatch_connection_broken = True
 
     def setUp(self):

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -2,6 +2,7 @@
 """Unit tests related to feature generation"""
 
 import unittest
+import warnings
 import os
 import json
 import boto3
@@ -39,7 +40,7 @@ class TestFeaturizer(unittest.TestCase):
     def test_feature_generation_full_model(self):
         processed_cycler_run_path = os.path.join(TEST_FILE_DIR, PROCESSED_CYCLER_FILE)
         with ScratchDir('.'):
-            os.environ['BEEP_ROOT'] = os.getcwd()
+            os.environ['BEEP_PROCESSING_DIR'] = os.getcwd()
             pcycler_run = loadfn(processed_cycler_run_path)
             featurizer = DeltaQFastCharge.from_run(processed_cycler_run_path, os.getcwd(), pcycler_run)
 
@@ -50,7 +51,7 @@ class TestFeaturizer(unittest.TestCase):
     def test_feature_old_class(self):
         processed_cycler_run_path = os.path.join(TEST_FILE_DIR, PROCESSED_CYCLER_FILE)
         with ScratchDir('.'):
-            os.environ['BEEP_ROOT'] = os.getcwd()
+            os.environ['BEEP_PROCESSING_DIR'] = os.getcwd()
             predictor = DegradationPredictor.from_processed_cycler_run_file(processed_cycler_run_path,
                                                                             features_label='full_model')
             self.assertEqual(predictor.feature_labels[4], "charge_time_cycles_1:5")
@@ -58,7 +59,7 @@ class TestFeaturizer(unittest.TestCase):
     def test_feature_label_full_model(self):
         processed_cycler_run_path = os.path.join(TEST_FILE_DIR, PROCESSED_CYCLER_FILE)
         with ScratchDir('.'):
-            os.environ['BEEP_ROOT'] = os.getcwd()
+            os.environ['BEEP_PROCESSING_DIR'] = os.getcwd()
             pcycler_run = loadfn(processed_cycler_run_path)
             featurizer = DeltaQFastCharge.from_run(processed_cycler_run_path, os.getcwd(), pcycler_run)
 
@@ -67,7 +68,7 @@ class TestFeaturizer(unittest.TestCase):
     def test_feature_serialization(self):
         processed_cycler_run_path = os.path.join(TEST_FILE_DIR, PROCESSED_CYCLER_FILE)
         with ScratchDir('.'):
-            os.environ['BEEP_ROOT'] = os.getcwd()
+            os.environ['BEEP_PROCESSING_DIR'] = os.getcwd()
             pcycler_run = loadfn(processed_cycler_run_path)
             featurizer = DeltaQFastCharge.from_run(processed_cycler_run_path, os.getcwd(), pcycler_run)
 
@@ -80,7 +81,7 @@ class TestFeaturizer(unittest.TestCase):
     def test_feature_serialization_for_training(self):
         processed_cycler_run_path = os.path.join(TEST_FILE_DIR, PROCESSED_CYCLER_FILE)
         with ScratchDir('.'):
-            os.environ['BEEP_ROOT'] = os.getcwd()
+            os.environ['BEEP_PROCESSING_DIR'] = os.getcwd()
             pcycler_run = loadfn(processed_cycler_run_path)
             featurizer = DeltaQFastCharge.from_run(processed_cycler_run_path, os.getcwd(), pcycler_run)
 
@@ -90,7 +91,7 @@ class TestFeaturizer(unittest.TestCase):
 
     def test_feature_class(self):
         with ScratchDir('.'):
-            os.environ['BEEP_ROOT'] = os.getcwd()
+            os.environ['BEEP_PROCESSING_DIR'] = os.getcwd()
 
             pcycler_run_loc = os.path.join(TEST_FILE_DIR, '2017-06-30_2C-10per_6C_CH10_structure.json')
             pcycler_run = loadfn(pcycler_run_loc)
@@ -136,7 +137,7 @@ class TestFeaturizer(unittest.TestCase):
     def test_feature_generation_list_to_json(self):
         processed_cycler_run_path = os.path.join(TEST_FILE_DIR, PROCESSED_CYCLER_FILE)
         with ScratchDir('.'):
-            os.environ['BEEP_ROOT'] = os.getcwd()
+            os.environ['BEEP_PROCESSING_DIR'] = os.getcwd()
 
             # Create dummy json obj
             json_obj = {
@@ -160,7 +161,7 @@ class TestFeaturizer(unittest.TestCase):
     def test_insufficient_data_file(self):
         processed_cycler_run_path = os.path.join(TEST_FILE_DIR, PROCESSED_CYCLER_FILE_INSUF)
         with ScratchDir('.'):
-            os.environ['BEEP_ROOT'] = os.getcwd()
+            os.environ['BEEP_PROCESSING_DIR'] = os.getcwd()
 
             json_obj = {
                         "mode": self.events_mode,

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -35,6 +35,7 @@ class TestFeaturizer(unittest.TestCase):
             response = kinesis.list_streams()
             self.events_mode = "test"
         except Exception as e:
+            warnings.warn("Cloud resources not configured")
             self.events_mode = "events_off"
 
     def test_feature_generation_full_model(self):
@@ -178,7 +179,7 @@ class TestFeaturizer(unittest.TestCase):
 
     def test_DiagnosticCyclesFeatures_class(self):
         with ScratchDir('.'):
-            os.environ['BEEP_ROOT'] = TEST_FILE_DIR
+            os.environ['BEEP_PROCESSING_DIR'] = TEST_FILE_DIR
             pcycler_run_loc = os.path.join(TEST_FILE_DIR, 'PreDiag_000240_000227_truncated_structure.json')
             pcycler_run = loadfn(pcycler_run_loc)
             featurizer = DiagnosticCyclesFeatures.from_run(pcycler_run_loc, os.getcwd(), pcycler_run)

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -8,7 +8,6 @@ import boto3
 import shutil
 
 import numpy as np
-from botocore.exceptions import NoRegionError, NoCredentialsError
 
 from beep.structure import RawCyclerRun, ProcessedCyclerRun
 from beep.featurize import process_file_list_from_json, \
@@ -34,7 +33,7 @@ class TestFeaturizer(unittest.TestCase):
             kinesis = boto3.client('kinesis')
             response = kinesis.list_streams()
             self.events_mode = "test"
-        except NoRegionError or NoCredentialsError as e:
+        except Exception as e:
             self.events_mode = "events_off"
 
     def test_feature_generation_full_model(self):

--- a/beep/tests/test_models.py
+++ b/beep/tests/test_models.py
@@ -2,6 +2,7 @@
 """Unit tests related to feature generation"""
 
 import unittest
+import warnings
 import os
 import json
 import numpy as np
@@ -28,6 +29,7 @@ class TestRunModel(unittest.TestCase):
             response = kinesis.list_streams()
             self.events_mode = "test"
         except Exception as e:
+            warnings.warn("Cloud resources not configured")
             self.events_mode = "events_off"
 
     def test_model_training_and_serialization(self):
@@ -140,6 +142,7 @@ class TestHelperFunctions(unittest.TestCase):
             response = kinesis.list_streams()
             self.events_mode = "test"
         except Exception as e:
+            warnings.warn("Cloud resources not configured")
             self.events_mode = "events_off"
 
     def test_get_project_name_from_list(self):

--- a/beep/tests/test_models.py
+++ b/beep/tests/test_models.py
@@ -11,7 +11,6 @@ from beep.run_model import DegradationModel, process_file_list_from_json, get_pr
 from monty.serialization import loadfn
 
 import boto3
-from botocore.exceptions import NoRegionError, NoCredentialsError
 
 TEST_DIR = os.path.dirname(__file__)
 TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
@@ -28,7 +27,7 @@ class TestRunModel(unittest.TestCase):
             kinesis = boto3.client('kinesis')
             response = kinesis.list_streams()
             self.events_mode = "test"
-        except NoRegionError or NoCredentialsError as e:
+        except Exception as e:
             self.events_mode = "events_off"
 
     def test_model_training_and_serialization(self):
@@ -140,7 +139,7 @@ class TestHelperFunctions(unittest.TestCase):
             kinesis = boto3.client('kinesis')
             response = kinesis.list_streams()
             self.events_mode = "test"
-        except NoRegionError or NoCredentialsError as e:
+        except Exception as e:
             self.events_mode = "events_off"
 
     def test_get_project_name_from_list(self):

--- a/beep/tests/test_protocol.py
+++ b/beep/tests/test_protocol.py
@@ -3,6 +3,7 @@
 
 import os
 import unittest
+import warnings
 import json
 import boto3
 import numpy as np
@@ -30,6 +31,7 @@ class GenerateProcedureTest(unittest.TestCase):
             response = kinesis.list_streams()
             self.events_mode = 'test'
         except Exception as e:
+            warnings.warn("Cloud resources not configured")
             self.events_mode = 'events_off'
 
     def test_dict_to_file_1(self):
@@ -190,8 +192,8 @@ class GenerateProcedureTest(unittest.TestCase):
 
         # Test script functionality
         with ScratchDir('.') as scratch_dir:
-            # Set BEEP_ROOT directory to scratch_dir
-            os.environ['BEEP_ROOT'] = os.getcwd()
+            # Set BEEP_PROCESSING_DIR directory to scratch_dir
+            os.environ['BEEP_PROCESSING_DIR'] = os.getcwd()
             procedures_path = os.path.join("data-share", "protocols", "procedures")
             names_path = os.path.join("data-share", "protocols", "names")
             makedirs_p(procedures_path)

--- a/beep/tests/test_protocol.py
+++ b/beep/tests/test_protocol.py
@@ -14,7 +14,6 @@ from beep.generate_protocol import ProcedureFile, \
 from monty.tempfile import ScratchDir
 from monty.serialization import dumpfn, loadfn
 from monty.os import makedirs_p
-from botocore.exceptions import NoRegionError, NoCredentialsError
 from beep.utils import os_format
 import difflib
 from sklearn.metrics import mean_absolute_error
@@ -30,7 +29,7 @@ class GenerateProcedureTest(unittest.TestCase):
             kinesis = boto3.client('kinesis')
             response = kinesis.list_streams()
             self.events_mode = 'test'
-        except NoRegionError or NoCredentialsError as e:
+        except Exception as e:
             self.events_mode = 'events_off'
 
     def test_dict_to_file_1(self):

--- a/beep/tests/test_structure.py
+++ b/beep/tests/test_structure.py
@@ -9,7 +9,6 @@ import boto3
 
 import numpy as np
 import pandas as pd
-from botocore.exceptions import NoRegionError, NoCredentialsError
 
 from beep import MODULE_DIR
 from beep.structure import RawCyclerRun, ProcessedCyclerRun, \
@@ -537,7 +536,7 @@ class CliTest(unittest.TestCase):
             kinesis = boto3.client('kinesis')
             response = kinesis.list_streams()
             self.events_mode = "test"
-        except NoRegionError or NoCredentialsError as e:
+        except Exception as e:
             self.events_mode = "events_off"
 
         self.arbin_file = os.path.join(TEST_FILE_DIR, "2017-12-04_4_65C-69per_6C_CH29.csv")
@@ -575,7 +574,7 @@ class ProcessedCyclerRunTest(unittest.TestCase):
             kinesis = boto3.client('kinesis')
             response = kinesis.list_streams()
             self.events_mode = "test"
-        except NoRegionError or NoCredentialsError as e:
+        except Exception as e:
             self.events_mode = "events_off"
 
         self.arbin_file = os.path.join(TEST_FILE_DIR, "FastCharge_000000_CH29.csv")

--- a/beep/tests/test_structure.py
+++ b/beep/tests/test_structure.py
@@ -5,6 +5,7 @@ import json
 import os
 import subprocess
 import unittest
+import warnings
 import boto3
 
 import numpy as np
@@ -226,7 +227,7 @@ class RawCyclerRunTest(unittest.TestCase):
 
     @unittest.skipUnless(BIG_FILE_TESTS, SKIP_MSG)
     def test_get_diagnostic(self):
-        os.environ['BEEP_ROOT'] = TEST_FILE_DIR
+        os.environ['BEEP_PROCESSING_DIR'] = TEST_FILE_DIR
 
         cycler_run = RawCyclerRun.from_file(self.maccor_file_w_parameters)
 
@@ -433,7 +434,7 @@ class RawCyclerRunTest(unittest.TestCase):
         self.assertEqual(project_name, "PredictionDiagnostics")
 
     def test_get_protocol_parameters(self):
-        os.environ['BEEP_ROOT'] = TEST_FILE_DIR
+        os.environ['BEEP_PROCESSING_DIR'] = TEST_FILE_DIR
         filepath = os.path.join(TEST_FILE_DIR, "PredictionDiagnostics_000109_tztest.010")
         test_path = os.path.join('data-share', 'raw', 'parameters')
         parameters, _ = get_protocol_parameters(filepath, parameters_path=test_path)
@@ -452,7 +453,7 @@ class RawCyclerRunTest(unittest.TestCase):
         self.assertIsNone(parameters)
 
     def test_determine_structering_parameters(self):
-        os.environ['BEEP_ROOT'] = TEST_FILE_DIR
+        os.environ['BEEP_PROCESSING_DIR'] = TEST_FILE_DIR
         raw_cycler_run = RawCyclerRun.from_file(self.maccor_file_timestamp)
         v_range, resolution, nominal_capacity, full_fast_charge, diagnostic_available = \
             raw_cycler_run.determine_structuring_parameters()
@@ -479,7 +480,7 @@ class RawCyclerRunTest(unittest.TestCase):
         self.assertEqual(diagnostic_available, diagnostic_available_test)
 
     def test_get_diagnostic_parameters(self):
-        os.environ['BEEP_ROOT'] = TEST_FILE_DIR
+        os.environ['BEEP_PROCESSING_DIR'] = TEST_FILE_DIR
         diagnostic_available = {'parameter_set': 'Tesla21700',
                                 'cycle_type': ['reset', 'hppc', 'rpt_0.2C', 'rpt_1C', 'rpt_2C'],
                                 'length': 5,
@@ -537,6 +538,7 @@ class CliTest(unittest.TestCase):
             response = kinesis.list_streams()
             self.events_mode = "test"
         except Exception as e:
+            warnings.warn("Cloud resources not configured")
             self.events_mode = "events_off"
 
         self.arbin_file = os.path.join(TEST_FILE_DIR, "2017-12-04_4_65C-69per_6C_CH29.csv")
@@ -544,7 +546,7 @@ class CliTest(unittest.TestCase):
     def test_simple_conversion(self):
         with ScratchDir('.'):
             # Set root env
-            os.environ['BEEP_ROOT'] = os.getcwd()
+            os.environ['BEEP_PROCESSING_DIR'] = os.getcwd()
             # Make necessary directories
             os.mkdir("data-share")
             os.mkdir(os.path.join("data-share", "structure"))
@@ -575,6 +577,7 @@ class ProcessedCyclerRunTest(unittest.TestCase):
             response = kinesis.list_streams()
             self.events_mode = "test"
         except Exception as e:
+            warnings.warn("Cloud resources not configured")
             self.events_mode = "events_off"
 
         self.arbin_file = os.path.join(TEST_FILE_DIR, "FastCharge_000000_CH29.csv")
@@ -677,7 +680,7 @@ class ProcessedCyclerRunTest(unittest.TestCase):
     def test_json_processing(self):
 
         with ScratchDir('.'):
-            os.environ['BEEP_ROOT'] = os.getcwd()
+            os.environ['BEEP_PROCESSING_DIR'] = os.getcwd()
             os.mkdir("data-share")
             os.mkdir(os.path.join("data-share", "structure"))
 
@@ -705,7 +708,7 @@ class ProcessedCyclerRunTest(unittest.TestCase):
 
         # Test same functionality with json file
         with ScratchDir('.'):
-            os.environ['BEEP_ROOT'] = os.getcwd()
+            os.environ['BEEP_PROCESSING_DIR'] = os.getcwd()
             os.mkdir("data-share")
             os.mkdir(os.path.join("data-share", "structure"))
 

--- a/beep/tests/test_validate.py
+++ b/beep/tests/test_validate.py
@@ -4,6 +4,7 @@
 import json
 import os
 import unittest
+import warnings
 
 import pandas as pd
 import numpy as np
@@ -27,6 +28,7 @@ class ValidationArbinTest(unittest.TestCase):
             response = kinesis.list_streams()
             self.events_mode = "test"
         except Exception as e:
+            warnings.warn("Cloud resources not configured")
             self.events_mode = "events_off"
 
     def test_validation_arbin_bad_index(self):
@@ -114,7 +116,7 @@ class ValidationArbinTest(unittest.TestCase):
 
     def test_validation_from_json(self):
         with ScratchDir('.'):
-            os.environ['BEEP_ROOT'] = os.getcwd()
+            os.environ['BEEP_PROCESSING_DIR'] = os.getcwd()
             os.mkdir("data-share")
             os.mkdir(os.path.join("data-share", "validation"))
             paths = ["2017-05-09_test-TC-contact_CH33.csv",
@@ -142,6 +144,7 @@ class ValidationMaccorTest(unittest.TestCase):
             response = kinesis.list_streams()
             self.events_mode = "test"
         except Exception as e:
+            warnings.warn("Cloud resources not configured")
             self.events_mode = "events_off"
 
     def test_validation_maccor(self):
@@ -151,13 +154,10 @@ class ValidationMaccorTest(unittest.TestCase):
         v = SimpleValidator(schema_filename=os.path.join(VALIDATION_SCHEMA_DIR, "schema-maccor-2170.yaml"))
         v.allow_unknown = True
         header = pd.read_csv(path, delimiter='\t', nrows=0)
-        print(header)
         df = pd.read_csv(path, delimiter='\t', skiprows=1)
         df['State'] = df['State'].astype(str)
         df['current'] = df['Amps']
-        print(df.dtypes)
         validity, reason = v.validate(df)
-        print(validity, reason)
         self.assertTrue(validity)
 
     def test_validate_from_paths_maccor(self):
@@ -169,8 +169,6 @@ class ValidationMaccorTest(unittest.TestCase):
                                                 skip_existing=False)
         df = pd.DataFrame(v.validation_records)
         df = df.transpose()
-        print(df)
-        print(df.loc["xTESLADIAG_000019_CH70.070", :])
         self.assertEqual(df.loc["xTESLADIAG_000019_CH70.070", "method"], "simple_maccor")
         self.assertEqual(df.loc["xTESLADIAG_000019_CH70.070", "validated"], True)
 
@@ -200,6 +198,7 @@ class SimpleValidatorTest(unittest.TestCase):
             response = kinesis.list_streams()
             self.events_mode = "test"
         except Exception as e:
+            warnings.warn("Cloud resources not configured")
             self.events_mode = "events_off"
 
     def test_file_incomplete(self):
@@ -279,7 +278,7 @@ class SimpleValidatorTest(unittest.TestCase):
 
     def test_validation_from_json(self):
         with ScratchDir('.'):
-            os.environ['BEEP_ROOT'] = os.getcwd()
+            os.environ['BEEP_PROCESSING_DIR'] = os.getcwd()
             os.mkdir("data-share")
             os.mkdir(os.path.join("data-share", "validation"))
             paths = ["2017-05-09_test-TC-contact_CH33.csv",

--- a/beep/tests/test_validate.py
+++ b/beep/tests/test_validate.py
@@ -9,7 +9,6 @@ import pandas as pd
 import numpy as np
 import boto3
 
-from botocore.exceptions import NoRegionError, NoCredentialsError
 from monty.tempfile import ScratchDir
 from beep.validate import ValidatorBeep, validate_file_list_from_json, \
     SimpleValidator
@@ -27,7 +26,7 @@ class ValidationArbinTest(unittest.TestCase):
             kinesis = boto3.client('kinesis')
             response = kinesis.list_streams()
             self.events_mode = "test"
-        except NoRegionError or NoCredentialsError as e:
+        except Exception as e:
             self.events_mode = "events_off"
 
     def test_validation_arbin_bad_index(self):
@@ -142,7 +141,7 @@ class ValidationMaccorTest(unittest.TestCase):
             kinesis = boto3.client('kinesis')
             response = kinesis.list_streams()
             self.events_mode = "test"
-        except NoRegionError or NoCredentialsError as e:
+        except Exception as e:
             self.events_mode = "events_off"
 
     def test_validation_maccor(self):
@@ -200,7 +199,7 @@ class SimpleValidatorTest(unittest.TestCase):
             kinesis = boto3.client('kinesis')
             response = kinesis.list_streams()
             self.events_mode = "test"
-        except NoRegionError or NoCredentialsError as e:
+        except Exception as e:
             self.events_mode = "events_off"
 
     def test_file_incomplete(self):


### PR DESCRIPTION
This is a new version of the Issue #45 PR that has been rebased to include new feature tests. This PR changes exception handling for the test setup and makes creation of directories automatic.

-Testing occurs in a variety of different environments and it's not possible to anticipate all of the exceptions that might occur when AWS resources are not available (no internet connection, no AWS credentials, incorrect credentials). Since the correct response to all of these situations is the same (proceed without AWS resources), having a general exception for this case seems justified.
-For new users, having to setup/understand the directory structure for the files is an unnecessary complication. As long as BEEP_PROCESSING_DIR is set correctly, creating the necessary directories for the files seems like the expected behavior.