### PR TITLE
Add outcomes as features

### DIFF
--- a/beep/featurize.py
+++ b/beep/featurize.py
@@ -739,6 +739,9 @@ class TrajectoryFastCharge(DeltaQFastCharge):
 
 class DiagnosticCapacities(DiagnosticCyclesFeatures):
     """
+    This class stores fractional levels of degradation in discharge capacity and discharge energy
+    relative to the first cycle at each diagnostic cycle, grouped by diagnostic cycle type.
+
         name (str): predictor object name.
         X (pandas.DataFrame): features in DataFrame format.
         metadata (dict): information about the conditions, data
@@ -756,8 +759,6 @@ class DiagnosticCapacities(DiagnosticCyclesFeatures):
     @classmethod
     def features_from_processed_cycler_run(cls, processed_cycler_run):
         """
-        Calculate the outcomes from the input data. In particular, the number of cycles
-        where we expect to reach certain thresholds of capacity loss
         Args:
             processed_cycler_run (beep.structure.ProcessedCyclerRun): data from cycler run
         Returns:

--- a/beep/featurize.py
+++ b/beep/featurize.py
@@ -739,7 +739,7 @@ class TrajectoryFastCharge(DeltaQFastCharge):
             thresh_max_cap=0.98, thresh_min_cap=0.78, interval_cap=0.03)
         return y
 
-class DiagnosticCapacities(DiagnosticCyclesFeatures):
+class DiagnosticProperties(DiagnosticCyclesFeatures):
     """
     This class stores fractional levels of degradation in discharge capacity and discharge energy
     relative to the first cycle at each diagnostic cycle, grouped by diagnostic cycle type.
@@ -750,7 +750,7 @@ class DiagnosticCapacities(DiagnosticCyclesFeatures):
             and code used to produce features
     """
     # Class name for the feature object
-    class_feature_name = 'DiagnosticCapacities'
+    class_feature_name = 'DiagnosticProperties'
 
     def __init__(self, name, X, metadata):
         super().__init__(name, X, metadata)
@@ -772,15 +772,16 @@ class DiagnosticCapacities(DiagnosticCyclesFeatures):
         X = pd.DataFrame()
         for quantity in quantities:
             for cycle_type in cycle_types:
-                summary_diag_cycle_type = cls.get_fractional_quantity_remaining(processed_cycler_run, quantity, cycle_type)
+                summary_diag_cycle_type = DiagnosticProperties.get_fractional_quantity_remaining(processed_cycler_run,
+                                                                                                 quantity, cycle_type)
                 summary_diag_cycle_type['cycle_type'] = cycle_type
                 summary_diag_cycle_type['metric'] = quantity
                 X = X.append(summary_diag_cycle_type)
 
         return X
 
-    @classmethod
-    def get_fractional_quantity_remaining(cls, processed_cycler_run, metric='discharge_energy',
+    @staticmethod
+    def get_fractional_quantity_remaining(processed_cycler_run, metric='discharge_energy',
                                           diagnostic_cycle_type='rpt_0.2C'):
         """
         Determine relative loss of <metric> in diagnostic_cycles of type <diagnostic_cycle_type> after 100 regular cycles
@@ -1049,9 +1050,7 @@ def add_file_prefix_to_path(path, prefix):
     return os.path.join(*split_path)
 
 
-def process_file_list_from_json(file_list_json, processed_dir='data-share/features/',
-                                features_label='full_model', predict_only=False,
-                                prediction_type="multi", predicted_quantity="cycle"):
+def process_file_list_from_json(file_list_json, processed_dir='data-share/features/'):
     """
     Function to take a json file containing processed cycler run file locations,
     extract features, dump the processed file into a predetermined directory,
@@ -1100,7 +1099,7 @@ def process_file_list_from_json(file_list_json, processed_dir='data-share/featur
         logger.info('run_id=%s featurizing=%s', str(run_id), path, extra=s)
         processed_cycler_run = loadfn(path)
 
-        featurizer_classes = [DeltaQFastCharge, TrajectoryFastCharge, DiagnosticCyclesFeatures, DiagnosticCapacities]
+        featurizer_classes = [DeltaQFastCharge, TrajectoryFastCharge, DiagnosticCyclesFeatures, DiagnosticProperties]
         for featurizer_class in featurizer_classes:
             featurizer = featurizer_class.from_run(path, processed_dir, processed_cycler_run)
             if featurizer:

--- a/beep/helpers/featurizer_helpers.py
+++ b/beep/helpers/featurizer_helpers.py
@@ -548,34 +548,3 @@ def get_relaxation_features(processed_cycler_run):
 
     return total_time_array[1] / total_time_array[0]
 
-
-def get_energy_fraction(diag_num, processed_cycler_run, remaining, metric, cycle_type, file):
-    """
-    This function can help us to get the dataframe that contains the diagnostic cycle index and energy fraction
-    which we can use to predict energy fraction later
-    Argument:
-            diag_num(int): diagnostic cycle number at which you want to get the feature, such as 37 or 142
-            processed_cycler_run(process_cycler_run object)
-            remaining(float): how much enegry left, such as 0.95
-            metric: such as discharge_energy
-            cycle_type: such as rpt_0.2C
-            file(str): a string that has the filename
-    Returns:
-            a dataframe that contains two columns cycle index and discharge energy fraction
-            Diagnostic cycles after the diagnostic cycle at which we generate the feature
-    """
-    summary_diag = processed_cycler_run.diagnostic_summary[processed_cycler_run.diagnostic_summary.cycle_type == cycle_type]
-    initial = summary_diag[metric].max()
-    threshold = remaining * initial
-    if summary_diag[metric].min() > threshold:
-        print('havent degraded to' + str(remaining) + metric + file)
-        return None
-    y = summary_diag[summary_diag[metric] < threshold].cycle_index.min()
-    if diag_num > y:
-        print('degraded before diagnostic cycle' + str(diag_num) + file)
-        return None
-    df = summary_diag[summary_diag['cycle_index'] > diag_num + 1]
-    result = pd.DataFrame()
-    result['cycle_index'] = df['cycle_index']
-    result['discharge_energy_fraction'] = df['discharge_energy'] / initial
-    return result

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from beep.structure import RawCyclerRun, ProcessedCyclerRun
 from beep.featurize import process_file_list_from_json, \
-    DeltaQFastCharge, TrajectoryFastCharge, DegradationPredictor, DiagnosticCyclesFeatures
+    DeltaQFastCharge, TrajectoryFastCharge, DegradationPredictor, DiagnosticCyclesFeatures, DiagnosticCapacities
 from monty.serialization import dumpfn, loadfn
 from monty.tempfile import ScratchDir
 
@@ -191,3 +191,16 @@ class TestFeaturizer(unittest.TestCase):
             self.assertTrue(all(x in featurizer.X.columns for x in ['m0_Mu','var(ocv)','var_charging_dQdV'])
 
 )
+    def test_DiagnosticCapacities_class(self):
+        with ScratchDir('.'):
+            os.environ['BEEP_PROCESSING_DIR'] = TEST_FILE_DIR
+            pcycler_run_loc = os.path.join(TEST_FILE_DIR, 'PreDiag_000240_000227_truncated_structure.json')
+            pcycler_run = loadfn(pcycler_run_loc)
+            featurizer = DiagnosticCapacities.from_run(pcycler_run_loc, os.getcwd(), pcycler_run)
+            path, local_filename = os.path.split(featurizer.name)
+            folder = os.path.split(path)[-1]
+            dumpfn(featurizer, featurizer.name)
+            self.assertEqual(folder, 'DiagnosticCapacities')
+            self.assertEqual(featurizer.X.shape, (10, 4))
+            print(featurizer.X.iloc[2,:])
+            self.assertListEqual(list(featurizer.X.iloc[2,:]), [143, 0.9753520623934744, 'rpt_0.2C','discharge_energy'])

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -136,9 +136,10 @@ class TestFeaturizer(unittest.TestCase):
             self.assertEqual(trajectory.X.loc[0, 'capacity_0.8'], 161)
 
     def test_feature_generation_list_to_json(self):
-        processed_cycler_run_path = os.path.join(TEST_FILE_DIR, PROCESSED_CYCLER_FILE)
+        processed_cycler_run_path = os.path.join(TEST_FILE_DIR, 'PreDiag_000240_000227_truncated_structure.json')
         with ScratchDir('.'):
-            os.environ['BEEP_PROCESSING_DIR'] = os.getcwd()
+            os.environ['BEEP_PROCESSING_DIR'] = TEST_FILE_DIR
+            #os.environ['BEEP_PROCESSING_DIR'] = os.getcwd()
 
             # Create dummy json obj
             json_obj = {
@@ -157,7 +158,10 @@ class TestFeaturizer(unittest.TestCase):
             # Ensure first is correct
             features_reloaded = loadfn(reloaded['file_list'][0])
             self.assertIsInstance(features_reloaded, DeltaQFastCharge)
-            self.assertEqual(features_reloaded.X.loc[0, 'nominal_capacity_by_median'], 1.0628421000000001)
+            self.assertEqual(features_reloaded.X.loc[0, 'nominal_capacity_by_median'], 0.07114775279999999)
+            features_reloaded = loadfn(reloaded['file_list'][-1])
+            self.assertIsInstance(features_reloaded, DiagnosticCapacities)
+            self.assertListEqual(list(features_reloaded.X.iloc[2,:]), [143, 0.9753520623934744, 'rpt_0.2C','discharge_energy'])
 
     def test_insufficient_data_file(self):
         processed_cycler_run_path = os.path.join(TEST_FILE_DIR, PROCESSED_CYCLER_FILE_INSUF)
@@ -202,5 +206,4 @@ class TestFeaturizer(unittest.TestCase):
             dumpfn(featurizer, featurizer.name)
             self.assertEqual(folder, 'DiagnosticCapacities')
             self.assertEqual(featurizer.X.shape, (10, 4))
-            print(featurizer.X.iloc[2,:])
             self.assertListEqual(list(featurizer.X.iloc[2,:]), [143, 0.9753520623934744, 'rpt_0.2C','discharge_energy'])

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from beep.structure import RawCyclerRun, ProcessedCyclerRun
 from beep.featurize import process_file_list_from_json, \
-    DeltaQFastCharge, TrajectoryFastCharge, DegradationPredictor, DiagnosticCyclesFeatures, DiagnosticCapacities
+    DeltaQFastCharge, TrajectoryFastCharge, DegradationPredictor, DiagnosticCyclesFeatures, DiagnosticProperties
 from monty.serialization import dumpfn, loadfn
 from monty.tempfile import ScratchDir
 
@@ -160,7 +160,7 @@ class TestFeaturizer(unittest.TestCase):
             self.assertIsInstance(features_reloaded, DeltaQFastCharge)
             self.assertEqual(features_reloaded.X.loc[0, 'nominal_capacity_by_median'], 0.07114775279999999)
             features_reloaded = loadfn(reloaded['file_list'][-1])
-            self.assertIsInstance(features_reloaded, DiagnosticCapacities)
+            self.assertIsInstance(features_reloaded, DiagnosticProperties)
             self.assertListEqual(list(features_reloaded.X.iloc[2,:]), [143, 0.9753520623934744, 'rpt_0.2C','discharge_energy'])
 
     def test_insufficient_data_file(self):
@@ -195,15 +195,15 @@ class TestFeaturizer(unittest.TestCase):
             self.assertTrue(all(x in featurizer.X.columns for x in ['m0_Mu','var(ocv)','var_charging_dQdV'])
 
 )
-    def test_DiagnosticCapacities_class(self):
+    def test_DiagnosticProperties_class(self):
         with ScratchDir('.'):
             os.environ['BEEP_PROCESSING_DIR'] = TEST_FILE_DIR
             pcycler_run_loc = os.path.join(TEST_FILE_DIR, 'PreDiag_000240_000227_truncated_structure.json')
             pcycler_run = loadfn(pcycler_run_loc)
-            featurizer = DiagnosticCapacities.from_run(pcycler_run_loc, os.getcwd(), pcycler_run)
+            featurizer = DiagnosticProperties.from_run(pcycler_run_loc, os.getcwd(), pcycler_run)
             path, local_filename = os.path.split(featurizer.name)
             folder = os.path.split(path)[-1]
             dumpfn(featurizer, featurizer.name)
-            self.assertEqual(folder, 'DiagnosticCapacities')
+            self.assertEqual(folder, 'DiagnosticProperties')
             self.assertEqual(featurizer.X.shape, (10, 4))
             self.assertListEqual(list(featurizer.X.iloc[2,:]), [143, 0.9753520623934744, 'rpt_0.2C','discharge_energy'])


### PR DESCRIPTION
PR adds a new class for storing outcomes for to predict trajectory of degradation. 
- Validation criteria are inherited from the class DiagnosticCyclesFeatures
- Outcome is calculated as fractional amount of a quantity (most commonly discharge energy or capacity) remaining relative to the first cycle at every diagnostic cycle, for each diagnostic cycle type (e.g. 'hppc', 'reset' ). If there are 5 unique diagnostic_cycles, 2 degradation quantities of interest and 10 eligible sets of  diagnostic cycles, there will be 100 rows in X
- Currently, the threshold above which the outcomes are calculated is hard-coded. These will be made into class arguments in a follow-up PR.

Features and outcomes derived from diagnostic cycles are now part of the pipeline