### PR TITLE
WIP: Mat 1735 turn off events if secrets not accessible

### DIFF
--- a/beep/tests/test_end_to_end.py
+++ b/beep/tests/test_end_to_end.py
@@ -1,22 +1,20 @@
 #  Copyright (c) 2019 Toyota Research Institute
 
 import unittest
-import warnings
 import os
 import shutil
 import subprocess
 import json
-import boto3
-import numpy as np
+
 import pandas as pd
 
 from tempfile import mkdtemp
 from monty.serialization import loadfn
 
 from beep import collate, validate, structure, featurize,\
-    run_model, ENVIRONMENT
+    run_model
 from beep.utils import os_format
-from beep.utils.secrets_manager import secret_accessible
+from beep.utils.secrets_manager import event_setup
 TEST_DIR = os.path.dirname(__file__)
 TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
 
@@ -24,17 +22,7 @@ TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
 class EndToEndTest(unittest.TestCase):
     def setUp(self):
         # Setup events for testing
-        if not secret_accessible(ENVIRONMENT):
-            self.events_mode = "events_off"
-        else:
-            try:
-                kinesis = boto3.client('kinesis')
-                response = kinesis.list_streams()
-                self.events_mode = "test"
-            except Exception as e:
-                warnings.warn("Cloud resources not configured")
-                self.events_mode = "events_off"
-
+        self.events_mode = event_setup()
 
         # Get cwd, create and enter scratch dir
         self.cwd = os.getcwd()

--- a/beep/tests/test_end_to_end.py
+++ b/beep/tests/test_end_to_end.py
@@ -14,23 +14,27 @@ from tempfile import mkdtemp
 from monty.serialization import loadfn
 
 from beep import collate, validate, structure, featurize,\
-    run_model, MODEL_DIR
+    run_model, ENVIRONMENT
 from beep.utils import os_format
-
+from beep.utils.secrets_manager import secret_accessible
 TEST_DIR = os.path.dirname(__file__)
 TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
 
 
 class EndToEndTest(unittest.TestCase):
     def setUp(self):
-        # Determine events mode for testing
-        try:
-            kinesis = boto3.client('kinesis')
-            response = kinesis.list_streams()
-            self.events_mode = 'test'
-        except Exception as e:
-            warnings.warn("Cloud resources not configured")
-            self.events_mode = 'events_off'
+        # Setup events for testing
+        if not secret_accessible(ENVIRONMENT):
+            self.events_mode = "events_off"
+        else:
+            try:
+                kinesis = boto3.client('kinesis')
+                response = kinesis.list_streams()
+                self.events_mode = "test"
+            except Exception as e:
+                warnings.warn("Cloud resources not configured")
+                self.events_mode = "events_off"
+
 
         # Get cwd, create and enter scratch dir
         self.cwd = os.getcwd()

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -2,15 +2,12 @@
 """Unit tests related to feature generation"""
 
 import unittest
-import warnings
 import os
 import json
-import boto3
 import shutil
 
 import numpy as np
-from beep import ENVIRONMENT
-from beep.utils.secrets_manager import secret_accessible
+from beep.utils.secrets_manager import event_setup
 from beep.featurize import process_file_list_from_json, \
     DeltaQFastCharge, TrajectoryFastCharge, DegradationPredictor, DiagnosticCyclesFeatures, DiagnosticProperties
 from monty.serialization import dumpfn, loadfn
@@ -29,17 +26,7 @@ SKIP_MSG = "Tests requiring large files with diagnostic cycles are disabled, set
 
 class TestFeaturizer(unittest.TestCase):
     def setUp(self):
-        # Setup events for testing
-        if not secret_accessible(ENVIRONMENT):
-            self.events_mode = "events_off"
-        else:
-            try:
-                kinesis = boto3.client('kinesis')
-                response = kinesis.list_streams()
-                self.events_mode = "test"
-            except Exception as e:
-                warnings.warn("Cloud resources not configured")
-                self.events_mode = "events_off"
+        self.events_mode = event_setup()
 
     def test_feature_generation_full_model(self):
         processed_cycler_run_path = os.path.join(TEST_FILE_DIR, PROCESSED_CYCLER_FILE)

--- a/beep/tests/test_models.py
+++ b/beep/tests/test_models.py
@@ -7,7 +7,8 @@ import os
 import json
 import numpy as np
 from glob import glob
-from beep import MODEL_DIR
+from beep import MODEL_DIR, ENVIRONMENT
+from beep.utils.secrets_manager import secret_accessible
 from beep.run_model import DegradationModel, process_file_list_from_json, get_project_name_from_list
 from monty.serialization import loadfn
 
@@ -24,13 +25,16 @@ MULTI_TASK_FEATURES_PATH = os.path.join(
 class TestRunModel(unittest.TestCase):
     def setUp(self):
         # Setup events for testing
-        try:
-            kinesis = boto3.client('kinesis')
-            response = kinesis.list_streams()
-            self.events_mode = "test"
-        except Exception as e:
-            warnings.warn("Cloud resources not configured")
+        if not secret_accessible(ENVIRONMENT):
             self.events_mode = "events_off"
+        else:
+            try:
+                kinesis = boto3.client('kinesis')
+                response = kinesis.list_streams()
+                self.events_mode = "test"
+            except Exception as e:
+                warnings.warn("Cloud resources not configured")
+                self.events_mode = "events_off"
 
     def test_model_training_and_serialization(self):
         # tests for model training and serialization
@@ -137,13 +141,17 @@ class TestRunModel(unittest.TestCase):
 class TestHelperFunctions(unittest.TestCase):
     def setUp(self):
         # Setup events for testing
-        try:
-            kinesis = boto3.client('kinesis')
-            response = kinesis.list_streams()
-            self.events_mode = "test"
-        except Exception as e:
-            warnings.warn("Cloud resources not configured")
+        if not secret_accessible(ENVIRONMENT):
             self.events_mode = "events_off"
+        else:
+            try:
+                kinesis = boto3.client('kinesis')
+                response = kinesis.list_streams()
+                self.events_mode = "test"
+            except Exception as e:
+                warnings.warn("Cloud resources not configured")
+                self.events_mode = "events_off"
+
 
     def test_get_project_name_from_list(self):
         file_list = ['data-share/predictions/PredictionDiagnostics_000100_003022_predictions.json',

--- a/beep/tests/test_models.py
+++ b/beep/tests/test_models.py
@@ -2,13 +2,12 @@
 """Unit tests related to feature generation"""
 
 import unittest
-import warnings
 import os
 import json
 import numpy as np
 from glob import glob
 from beep import MODEL_DIR, ENVIRONMENT
-from beep.utils.secrets_manager import secret_accessible
+from beep.utils.secrets_manager import event_setup
 from beep.run_model import DegradationModel, process_file_list_from_json, get_project_name_from_list
 from monty.serialization import loadfn
 
@@ -24,17 +23,7 @@ MULTI_TASK_FEATURES_PATH = os.path.join(
 
 class TestRunModel(unittest.TestCase):
     def setUp(self):
-        # Setup events for testing
-        if not secret_accessible(ENVIRONMENT):
-            self.events_mode = "events_off"
-        else:
-            try:
-                kinesis = boto3.client('kinesis')
-                response = kinesis.list_streams()
-                self.events_mode = "test"
-            except Exception as e:
-                warnings.warn("Cloud resources not configured")
-                self.events_mode = "events_off"
+        self.events_mode = event_setup()
 
     def test_model_training_and_serialization(self):
         # tests for model training and serialization
@@ -139,20 +128,6 @@ class TestRunModel(unittest.TestCase):
 
 
 class TestHelperFunctions(unittest.TestCase):
-    def setUp(self):
-        # Setup events for testing
-        if not secret_accessible(ENVIRONMENT):
-            self.events_mode = "events_off"
-        else:
-            try:
-                kinesis = boto3.client('kinesis')
-                response = kinesis.list_streams()
-                self.events_mode = "test"
-            except Exception as e:
-                warnings.warn("Cloud resources not configured")
-                self.events_mode = "events_off"
-
-
     def test_get_project_name_from_list(self):
         file_list = ['data-share/predictions/PredictionDiagnostics_000100_003022_predictions.json',
                      'data-share/predictions/PredictionDiagnostics_000101_003022_predictions.json',

--- a/beep/tests/test_protocol.py
+++ b/beep/tests/test_protocol.py
@@ -9,7 +9,7 @@ import boto3
 import numpy as np
 import datetime
 import pandas as pd
-from beep import PROCEDURE_TEMPLATE_DIR
+from beep import PROCEDURE_TEMPLATE_DIR, ENVIRONMENT
 from beep.generate_protocol import ProcedureFile, \
     generate_protocol_files_from_csv, convert_velocity_to_power_waveform, generate_maccor_waveform_file
 from monty.tempfile import ScratchDir
@@ -17,7 +17,7 @@ from monty.serialization import dumpfn, loadfn
 from monty.os import makedirs_p
 from beep.utils import os_format
 import difflib
-from sklearn.metrics import mean_absolute_error
+from beep.utils.secrets_manager import secret_accessible
 
 TEST_DIR = os.path.dirname(__file__)
 TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
@@ -25,14 +25,18 @@ TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
 
 class GenerateProcedureTest(unittest.TestCase):
     def setUp(self):
-        # Determine events mode for testing
-        try:
-            kinesis = boto3.client('kinesis')
-            response = kinesis.list_streams()
-            self.events_mode = 'test'
-        except Exception as e:
-            warnings.warn("Cloud resources not configured")
-            self.events_mode = 'events_off'
+        # Setup events for testing
+        if not secret_accessible(ENVIRONMENT):
+            self.events_mode = "events_off"
+        else:
+            try:
+                kinesis = boto3.client('kinesis')
+                response = kinesis.list_streams()
+                self.events_mode = "test"
+            except Exception as e:
+                warnings.warn("Cloud resources not configured")
+                self.events_mode = "events_off"
+
 
     def test_dict_to_file_1(self):
         sdu = ProcedureFile(version='0.1')

--- a/beep/tests/test_protocol.py
+++ b/beep/tests/test_protocol.py
@@ -22,21 +22,23 @@ from beep.utils.secrets_manager import secret_accessible
 TEST_DIR = os.path.dirname(__file__)
 TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
 
+def event_setup():
+    # Setup events for testing
+    if not secret_accessible(ENVIRONMENT):
+        events_mode = "events_off"
+    else:
+        try:
+            kinesis = boto3.client('kinesis')
+            response = kinesis.list_streams()
+            events_mode = "test"
+        except Exception as e:
+            warnings.warn("Cloud resources not configured")
+            events_mode = "events_off"
+    return events_mode
 
 class GenerateProcedureTest(unittest.TestCase):
     def setUp(self):
-        # Setup events for testing
-        if not secret_accessible(ENVIRONMENT):
-            self.events_mode = "events_off"
-        else:
-            try:
-                kinesis = boto3.client('kinesis')
-                response = kinesis.list_streams()
-                self.events_mode = "test"
-            except Exception as e:
-                warnings.warn("Cloud resources not configured")
-                self.events_mode = "events_off"
-
+        self.events_mode = event_setup()
 
     def test_dict_to_file_1(self):
         sdu = ProcedureFile(version='0.1')

--- a/beep/tests/test_secrets_manager.py
+++ b/beep/tests/test_secrets_manager.py
@@ -5,7 +5,7 @@ import os
 import unittest
 from beep import ENVIRONMENT
 from beep.config import config
-from beep.utils.secrets_manager import secret_accessible, get_secret
+from beep.utils.secrets_manager import secret_accessible, get_secret, event_setup
 
 TEST_DIR = os.path.dirname(__file__)
 TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")

--- a/beep/tests/test_structure.py
+++ b/beep/tests/test_structure.py
@@ -11,7 +11,7 @@ import boto3
 import numpy as np
 import pandas as pd
 
-from beep import MODULE_DIR
+from beep import MODULE_DIR, ENVIRONMENT
 from beep.structure import RawCyclerRun, ProcessedCyclerRun, \
     process_file_list_from_json, EISpectrum, get_project_sequence, \
     get_protocol_parameters, get_diagnostic_parameters, \
@@ -20,6 +20,7 @@ from beep.conversion_schemas import STRUCTURE_DTYPES
 from monty.serialization import loadfn, dumpfn
 from monty.tempfile import ScratchDir
 from beep.utils import os_format
+from beep.utils.secrets_manager import secret_accessible
 import matplotlib.pyplot as plt
 
 BIG_FILE_TESTS = os.environ.get("BEEP_BIG_TESTS", False)
@@ -536,13 +537,16 @@ class RawCyclerRunTest(unittest.TestCase):
 class CliTest(unittest.TestCase):
     def setUp(self):
         # Setup events for testing
-        try:
-            kinesis = boto3.client('kinesis')
-            response = kinesis.list_streams()
-            self.events_mode = "test"
-        except Exception as e:
-            warnings.warn("Cloud resources not configured")
+        if not secret_accessible(ENVIRONMENT):
             self.events_mode = "events_off"
+        else:
+            try:
+                kinesis = boto3.client('kinesis')
+                response = kinesis.list_streams()
+                self.events_mode = "test"
+            except Exception as e:
+                warnings.warn("Cloud resources not configured")
+                self.events_mode = "events_off"
 
         self.arbin_file = os.path.join(TEST_FILE_DIR, "2017-12-04_4_65C-69per_6C_CH29.csv")
 
@@ -575,13 +579,16 @@ class CliTest(unittest.TestCase):
 class ProcessedCyclerRunTest(unittest.TestCase):
     def setUp(self):
         # Setup events for testing
-        try:
-            kinesis = boto3.client('kinesis')
-            response = kinesis.list_streams()
-            self.events_mode = "test"
-        except Exception as e:
-            warnings.warn("Cloud resources not configured")
+        if not secret_accessible(ENVIRONMENT):
             self.events_mode = "events_off"
+        else:
+            try:
+                kinesis = boto3.client('kinesis')
+                response = kinesis.list_streams()
+                self.events_mode = "test"
+            except Exception as e:
+                warnings.warn("Cloud resources not configured")
+                self.events_mode = "events_off"
 
         self.arbin_file = os.path.join(TEST_FILE_DIR, "FastCharge_000000_CH29.csv")
         self.maccor_file = os.path.join(TEST_FILE_DIR, "xTESLADIAG_000019_CH70.070")

--- a/beep/tests/test_structure.py
+++ b/beep/tests/test_structure.py
@@ -5,13 +5,10 @@ import json
 import os
 import subprocess
 import unittest
-import warnings
-import boto3
-
 import numpy as np
 import pandas as pd
 
-from beep import MODULE_DIR, ENVIRONMENT
+from beep import MODULE_DIR
 from beep.structure import RawCyclerRun, ProcessedCyclerRun, \
     process_file_list_from_json, EISpectrum, get_project_sequence, \
     get_protocol_parameters, get_diagnostic_parameters, \
@@ -20,7 +17,7 @@ from beep.conversion_schemas import STRUCTURE_DTYPES
 from monty.serialization import loadfn, dumpfn
 from monty.tempfile import ScratchDir
 from beep.utils import os_format
-from beep.utils.secrets_manager import secret_accessible
+from beep.utils.secrets_manager import event_setup
 import matplotlib.pyplot as plt
 
 BIG_FILE_TESTS = os.environ.get("BEEP_BIG_TESTS", False)
@@ -536,18 +533,7 @@ class RawCyclerRunTest(unittest.TestCase):
 
 class CliTest(unittest.TestCase):
     def setUp(self):
-        # Setup events for testing
-        if not secret_accessible(ENVIRONMENT):
-            self.events_mode = "events_off"
-        else:
-            try:
-                kinesis = boto3.client('kinesis')
-                response = kinesis.list_streams()
-                self.events_mode = "test"
-            except Exception as e:
-                warnings.warn("Cloud resources not configured")
-                self.events_mode = "events_off"
-
+        self.events_mode = event_setup()
         self.arbin_file = os.path.join(TEST_FILE_DIR, "2017-12-04_4_65C-69per_6C_CH29.csv")
 
     def test_simple_conversion(self):
@@ -578,17 +564,7 @@ class CliTest(unittest.TestCase):
 
 class ProcessedCyclerRunTest(unittest.TestCase):
     def setUp(self):
-        # Setup events for testing
-        if not secret_accessible(ENVIRONMENT):
-            self.events_mode = "events_off"
-        else:
-            try:
-                kinesis = boto3.client('kinesis')
-                response = kinesis.list_streams()
-                self.events_mode = "test"
-            except Exception as e:
-                warnings.warn("Cloud resources not configured")
-                self.events_mode = "events_off"
+        self.events_mode = event_setup()
 
         self.arbin_file = os.path.join(TEST_FILE_DIR, "FastCharge_000000_CH29.csv")
         self.maccor_file = os.path.join(TEST_FILE_DIR, "xTESLADIAG_000019_CH70.070")

--- a/beep/tests/test_validate.py
+++ b/beep/tests/test_validate.py
@@ -13,8 +13,8 @@ import boto3
 from monty.tempfile import ScratchDir
 from beep.validate import ValidatorBeep, validate_file_list_from_json, \
     SimpleValidator
-from beep import S3_CACHE, VALIDATION_SCHEMA_DIR
-
+from beep import S3_CACHE, VALIDATION_SCHEMA_DIR, ENVIRONMENT
+from beep.utils.secrets_manager import secret_accessible
 TEST_DIR = os.path.dirname(__file__)
 TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
 
@@ -23,13 +23,17 @@ TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
 class ValidationArbinTest(unittest.TestCase):
     def setUp(self):
         # Setup events for testing
-        try:
-            kinesis = boto3.client('kinesis')
-            response = kinesis.list_streams()
-            self.events_mode = "test"
-        except Exception as e:
-            warnings.warn("Cloud resources not configured")
+        if not secret_accessible(ENVIRONMENT):
             self.events_mode = "events_off"
+        else:
+            try:
+                kinesis = boto3.client('kinesis')
+                response = kinesis.list_streams()
+                self.events_mode = "test"
+            except Exception as e:
+                warnings.warn("Cloud resources not configured")
+                self.events_mode = "events_off"
+
 
     def test_validation_arbin_bad_index(self):
         path = "2017-05-09_test-TC-contact_CH33.csv"
@@ -139,13 +143,17 @@ class ValidationMaccorTest(unittest.TestCase):
     # To further develop as Maccor data / schema becomes available
     def setUp(self):
         # Setup events for testing
-        try:
-            kinesis = boto3.client('kinesis')
-            response = kinesis.list_streams()
-            self.events_mode = "test"
-        except Exception as e:
-            warnings.warn("Cloud resources not configured")
+        if not secret_accessible(ENVIRONMENT):
             self.events_mode = "events_off"
+        else:
+            try:
+                kinesis = boto3.client('kinesis')
+                response = kinesis.list_streams()
+                self.events_mode = "test"
+            except Exception as e:
+                warnings.warn("Cloud resources not configured")
+                self.events_mode = "events_off"
+
 
     def test_validation_maccor(self):
         path = "xTESLADIAG_000019_CH70.070"
@@ -210,13 +218,17 @@ class ValidationEisTest(unittest.TestCase):
 class SimpleValidatorTest(unittest.TestCase):
     def setUp(self):
         # Setup events for testing
-        try:
-            kinesis = boto3.client('kinesis')
-            response = kinesis.list_streams()
-            self.events_mode = "test"
-        except Exception as e:
-            warnings.warn("Cloud resources not configured")
+        if not secret_accessible(ENVIRONMENT):
             self.events_mode = "events_off"
+        else:
+            try:
+                kinesis = boto3.client('kinesis')
+                response = kinesis.list_streams()
+                self.events_mode = "test"
+            except Exception as e:
+                warnings.warn("Cloud resources not configured")
+                self.events_mode = "events_off"
+
 
     def test_file_incomplete(self):
         path = "FastCharge_000025_CH8.csv"

--- a/beep/tests/test_validate.py
+++ b/beep/tests/test_validate.py
@@ -4,17 +4,13 @@
 import json
 import os
 import unittest
-import warnings
-
 import pandas as pd
 import numpy as np
-import boto3
-
 from monty.tempfile import ScratchDir
 from beep.validate import ValidatorBeep, validate_file_list_from_json, \
     SimpleValidator
-from beep import S3_CACHE, VALIDATION_SCHEMA_DIR, ENVIRONMENT
-from beep.utils.secrets_manager import secret_accessible
+from beep import S3_CACHE, VALIDATION_SCHEMA_DIR
+from beep.utils.secrets_manager import event_setup
 TEST_DIR = os.path.dirname(__file__)
 TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
 
@@ -23,17 +19,7 @@ TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
 class ValidationArbinTest(unittest.TestCase):
     def setUp(self):
         # Setup events for testing
-        if not secret_accessible(ENVIRONMENT):
-            self.events_mode = "events_off"
-        else:
-            try:
-                kinesis = boto3.client('kinesis')
-                response = kinesis.list_streams()
-                self.events_mode = "test"
-            except Exception as e:
-                warnings.warn("Cloud resources not configured")
-                self.events_mode = "events_off"
-
+        self.events_mode = event_setup()
 
     def test_validation_arbin_bad_index(self):
         path = "2017-05-09_test-TC-contact_CH33.csv"
@@ -143,17 +129,7 @@ class ValidationMaccorTest(unittest.TestCase):
     # To further develop as Maccor data / schema becomes available
     def setUp(self):
         # Setup events for testing
-        if not secret_accessible(ENVIRONMENT):
-            self.events_mode = "events_off"
-        else:
-            try:
-                kinesis = boto3.client('kinesis')
-                response = kinesis.list_streams()
-                self.events_mode = "test"
-            except Exception as e:
-                warnings.warn("Cloud resources not configured")
-                self.events_mode = "events_off"
-
+        self.events_mode = event_setup()
 
     def test_validation_maccor(self):
         path = "xTESLADIAG_000019_CH70.070"
@@ -218,17 +194,7 @@ class ValidationEisTest(unittest.TestCase):
 class SimpleValidatorTest(unittest.TestCase):
     def setUp(self):
         # Setup events for testing
-        if not secret_accessible(ENVIRONMENT):
-            self.events_mode = "events_off"
-        else:
-            try:
-                kinesis = boto3.client('kinesis')
-                response = kinesis.list_streams()
-                self.events_mode = "test"
-            except Exception as e:
-                warnings.warn("Cloud resources not configured")
-                self.events_mode = "events_off"
-
+        self.events_mode = event_setup()
 
     def test_file_incomplete(self):
         path = "FastCharge_000025_CH8.csv"

--- a/beep/utils/secrets_manager.py
+++ b/beep/utils/secrets_manager.py
@@ -41,7 +41,6 @@ def get_secret(secret_name):
         secret          dict object containing database credentials
 
     """
-
     region_name = 'us-west-2'
 
     # Create a Secrets Manager client

--- a/beep/utils/secrets_manager.py
+++ b/beep/utils/secrets_manager.py
@@ -41,6 +41,7 @@ def get_secret(secret_name):
         secret          dict object containing database credentials
 
     """
+
     region_name = 'us-west-2'
 
     # Create a Secrets Manager client

--- a/beep/utils/secrets_manager.py
+++ b/beep/utils/secrets_manager.py
@@ -10,9 +10,10 @@ Current environments:
 
 import boto3
 import base64
+import warnings
 from botocore.exceptions import ClientError
 import json
-
+from beep import ENVIRONMENT
 from beep.config import config
 
 
@@ -68,3 +69,17 @@ def get_secret(secret_name):
                 get_secret_value_response['SecretBinary'])
             return json.loads(decoded_binary_secret)
 
+
+def event_setup():
+    # Setup events for testing
+    if not secret_accessible(ENVIRONMENT):
+        events_mode = "events_off"
+    else:
+        try:
+            kinesis = boto3.client('kinesis')
+            response = kinesis.list_streams()
+            events_mode = "test"
+        except Exception as e:
+            warnings.warn("Cloud resources not configured")
+            events_mode = "events_off"
+    return events_mode


### PR DESCRIPTION
PR to fix an [issue](https://github.com/TRI-AMDD/beep/issues/54) relating to AWS credentialing. 
In the test class setup, I check if `secret_accessible(ENVIRONMENT)` returns True. If not, mode is set to `events_off`.  This should handle situations where a user has an AWS account, but not the right secrets for beep aws resources.