### PR TITLE
try pytest-cov removal

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,7 @@ setup(name="beep",
 
                         ],
       extras_require={
-          "tests": ["pytest",
-                    "pytest-cov",
+          "tests": ["pytest-cov",
                     "coveralls",
                     "memory_profiler",
                     "matplotlib"]


### PR DESCRIPTION
Should fix unittest issue, installs pytest-cov without pytest dependency conflict.