### PR TITLE
Include notebook used to demonstrate the use of beep 

### DIFF
--- a/beep/tutorials/quick-start.ipynb
+++ b/beep/tutorials/quick-start.ipynb
@@ -1,0 +1,445 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Quick Start Tutorial\n",
+    "This notebook is meant to demonstrate basic usage of the beep package with data from \"Data-driven prediction of battery cycle life before capacity degradation\" KA Severson, et al. Nature Energy 4 (5), 383-391\n",
+    "\n",
+    "This data is available for download from https://data.matr.io/1/ . For brevity, only one test is included in this notebook but the example can easily be extended to a larger number of files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting beep\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/aa/fc/bb3821d052f31b053b7eee0c78f1b5246e44166707a2c994689409076004/beep-2020.5.24-py3-none-any.whl (108kB)\n",
+      "\u001b[K    100% |████████████████████████████████| 112kB 5.0MB/s ta 0:00:01\n",
+      "\u001b[?25hCollecting xmltodict==0.12.0 (from beep)\n",
+      "  Downloading https://files.pythonhosted.org/packages/28/fd/30d5c1d3ac29ce229f6bdc40bbc20b28f716e8b363140c26eff19122d8a5/xmltodict-0.12.0-py2.py3-none-any.whl\n",
+      "Collecting tqdm==4.43.0 (from beep)\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/47/55/fd9170ba08a1a64a18a7f8a18f088037316f2a41be04d2fe6ece5a653e8f/tqdm-4.43.0-py2.py3-none-any.whl (59kB)\n",
+      "\u001b[K    100% |████████████████████████████████| 61kB 18.1MB/s ta 0:00:01\n",
+      "\u001b[?25hCollecting psycopg2==2.7.7 (from beep)\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/37/25/53e8398975aa3323de46a5cc2745aeb4c9db11352ca905d3a15c53b6a816/psycopg2-2.7.7-cp36-cp36m-manylinux1_x86_64.whl (2.7MB)\n",
+      "\u001b[K    100% |████████████████████████████████| 2.7MB 12.2MB/s ta 0:00:01\n",
+      "\u001b[?25hCollecting monty[yaml]==3.0.2 (from beep)\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/b1/a4/d57b127ad2103ebc1a21a9c6379abc10d5f57f5d92cac86532c15a43818f/monty-3.0.2-py3-none-any.whl (61kB)\n",
+      "\u001b[K    100% |████████████████████████████████| 61kB 27.5MB/s ta 0:00:01\n",
+      "\u001b[?25hCollecting numpy==1.18.1 (from beep)\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/62/20/4d43e141b5bc426ba38274933ef8e76e85c7adea2c321ecf9ebf7421cedf/numpy-1.18.1-cp36-cp36m-manylinux1_x86_64.whl (20.1MB)\n",
+      "\u001b[K    100% |████████████████████████████████| 20.2MB 2.4MB/s eta 0:00:01\n",
+      "\u001b[?25hCollecting scipy==1.4.1 (from beep)\n",
+      "  Using cached https://files.pythonhosted.org/packages/dc/29/162476fd44203116e7980cfbd9352eef9db37c49445d1fec35509022f6aa/scipy-1.4.1-cp36-cp36m-manylinux1_x86_64.whl\n",
+      "Requirement already satisfied: scikit-learn==0.20.3 in /home/ec2-user/anaconda3/envs/python3/lib/python3.6/site-packages (from beep) (0.20.3)\n",
+      "Requirement already satisfied: docopt==0.6.2 in /home/ec2-user/anaconda3/envs/python3/lib/python3.6/site-packages (from beep) (0.6.2)\n",
+      "Collecting lmfit==1.0.1 (from beep)\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/d1/2e/9e4cdcebf93603ce57bc7577707ad56ed1282ae306f611e525612b9cfeea/lmfit-1.0.1.tar.gz (258kB)\n",
+      "\u001b[K    100% |████████████████████████████████| 266kB 36.9MB/s ta 0:00:01\n",
+      "\u001b[?25hCollecting pytz==2019.3 (from beep)\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/e7/f9/f0b53f88060247251bf481fa6ea62cd0d25bf1b11a87888e53ce5b7c8ad2/pytz-2019.3-py2.py3-none-any.whl (509kB)\n",
+      "\u001b[K    100% |████████████████████████████████| 512kB 31.9MB/s ta 0:00:01\n",
+      "\u001b[?25hCollecting python-dateutil==2.8.0 (from beep)\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/41/17/c62faccbfbd163c7f57f3844689e3a78bae1f403648a6afb1d0866d87fbb/python_dateutil-2.8.0-py2.py3-none-any.whl (226kB)\n",
+      "\u001b[K    100% |████████████████████████████████| 235kB 40.4MB/s ta 0:00:01\n",
+      "\u001b[?25hCollecting pandas==1.0.1 (from beep)\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/08/ec/b5dd8cfb078380fb5ae9325771146bccd4e8cad2d3e4c72c7433010684eb/pandas-1.0.1-cp36-cp36m-manylinux1_x86_64.whl (10.1MB)\n",
+      "\u001b[K    100% |████████████████████████████████| 10.1MB 5.6MB/s eta 0:00:01\n",
+      "\u001b[?25hCollecting cerberus==1.3.2 (from beep)\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/90/a7/71c6ed2d46a81065e68c007ac63378b96fa54c7bb614d653c68232f9c50c/Cerberus-1.3.2.tar.gz (52kB)\n",
+      "\u001b[K    100% |████████████████████████████████| 61kB 30.8MB/s ta 0:00:01\n",
+      "\u001b[?25hCollecting botocore==1.15.4 (from beep)\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/90/77/9375acdf2975cc4352e6f8895f254398ff475517bfeeb505e68b16f581a6/botocore-1.15.4-py2.py3-none-any.whl (5.9MB)\n",
+      "\u001b[K    100% |████████████████████████████████| 5.9MB 9.1MB/s eta 0:00:01\n",
+      "\u001b[?25hRequirement already satisfied: msgpack-python==0.5.6 in /home/ec2-user/anaconda3/envs/python3/lib/python3.6/site-packages (from beep) (0.5.6)\n",
+      "Collecting boto3==1.12.4 (from beep)\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/45/e9/3ce5df81d70dc3cd19e71bc5b741cad7ff04b7748c46ec545875de89cfb1/boto3-1.12.4-py2.py3-none-any.whl (128kB)\n",
+      "\u001b[K    100% |████████████████████████████████| 133kB 41.3MB/s ta 0:00:01\n",
+      "\u001b[?25hCollecting watchtower==0.7.3 (from beep)\n",
+      "  Downloading https://files.pythonhosted.org/packages/e1/ad/a891df8edb54720c981b1f696611292ce24c8e02a20898f32efcb9d1f5ff/watchtower-0.7.3-py2.py3-none-any.whl\n",
+      "Collecting tables==3.6.1 (from beep)\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/ed/c3/8fd9e3bb21872f9d69eb93b3014c86479864cca94e625fd03713ccacec80/tables-3.6.1-cp36-cp36m-manylinux1_x86_64.whl (4.3MB)\n",
+      "\u001b[K    100% |████████████████████████████████| 4.3MB 15.5MB/s ta 0:00:01\n",
+      "\u001b[?25hCollecting ruamel.yaml; extra == \"yaml\" (from monty[yaml]==3.0.2->beep)\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/a6/92/59af3e38227b9cc14520bf1e59516d99ceca53e3b8448094248171e9432b/ruamel.yaml-0.16.10-py2.py3-none-any.whl (111kB)\n",
+      "\u001b[K    100% |████████████████████████████████| 112kB 34.8MB/s ta 0:00:01\n",
+      "\u001b[?25hCollecting asteval>=0.9.16 (from lmfit==1.0.1->beep)\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/e4/3b/8aaee90977588fa3e88d7a495af306d6f4a1c1c01c8f0fe0de1fc43d0908/asteval-0.9.18.tar.gz (52kB)\n",
+      "\u001b[K    100% |████████████████████████████████| 61kB 30.2MB/s ta 0:00:01\n",
+      "\u001b[?25hCollecting uncertainties>=3.0.1 (from lmfit==1.0.1->beep)\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/2a/c2/babbe5b16141859dd799ed31c03987100a7b6d0ca7c0ed4429c96ce60fdf/uncertainties-3.1.2.tar.gz (232kB)\n",
+      "\u001b[K    100% |████████████████████████████████| 235kB 37.7MB/s ta 0:00:01\n",
+      "\u001b[?25hRequirement already satisfied: six>=1.5 in /home/ec2-user/anaconda3/envs/python3/lib/python3.6/site-packages (from python-dateutil==2.8.0->beep) (1.11.0)\n",
+      "Requirement already satisfied: setuptools in /home/ec2-user/anaconda3/envs/python3/lib/python3.6/site-packages (from cerberus==1.3.2->beep) (39.1.0)\n",
+      "Requirement already satisfied: docutils<0.16,>=0.10 in /home/ec2-user/anaconda3/envs/python3/lib/python3.6/site-packages (from botocore==1.15.4->beep) (0.14)\n",
+      "Requirement already satisfied: jmespath<1.0.0,>=0.7.1 in /home/ec2-user/anaconda3/envs/python3/lib/python3.6/site-packages (from botocore==1.15.4->beep) (0.9.4)\n",
+      "Requirement already satisfied: urllib3<1.26,>=1.20; python_version != \"3.4\" in /home/ec2-user/anaconda3/envs/python3/lib/python3.6/site-packages (from botocore==1.15.4->beep) (1.23)\n",
+      "Requirement already satisfied: s3transfer<0.4.0,>=0.3.0 in /home/ec2-user/anaconda3/envs/python3/lib/python3.6/site-packages (from boto3==1.12.4->beep) (0.3.3)\n",
+      "Requirement already satisfied: numexpr>=2.6.2 in /home/ec2-user/anaconda3/envs/python3/lib/python3.6/site-packages (from tables==3.6.1->beep) (2.6.5)\n",
+      "Collecting ruamel.yaml.clib>=0.1.2; platform_python_implementation == \"CPython\" and python_version < \"3.9\" (from ruamel.yaml; extra == \"yaml\"->monty[yaml]==3.0.2->beep)\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/53/77/4bcd63f362bcb6c8f4f06253c11f9772f64189bf08cf3f40c5ccbda9e561/ruamel.yaml.clib-0.2.0-cp36-cp36m-manylinux1_x86_64.whl (548kB)\n",
+      "\u001b[K    100% |████████████████████████████████| 552kB 29.9MB/s ta 0:00:01\n",
+      "\u001b[?25hBuilding wheels for collected packages: lmfit, cerberus, asteval, uncertainties\n",
+      "  Running setup.py bdist_wheel for lmfit ... \u001b[?25ldone\n",
+      "\u001b[?25h  Stored in directory: /home/ec2-user/.cache/pip/wheels/ef/22/8d/6cd9c0af36f501cfb248673b05dad5d2c27504951d55519acb\n",
+      "  Running setup.py bdist_wheel for cerberus ... \u001b[?25ldone\n",
+      "\u001b[?25h  Stored in directory: /home/ec2-user/.cache/pip/wheels/e9/38/1f/f2cc84182676f3ae7134b9b2d744f9c235b24d2ddc8f7fe465\n",
+      "  Running setup.py bdist_wheel for asteval ... \u001b[?25ldone\n",
+      "\u001b[?25h  Stored in directory: /home/ec2-user/.cache/pip/wheels/1c/53/1b/28d929700c9633b1786a4982e6db564ec8326a8930234dcc19\n",
+      "  Running setup.py bdist_wheel for uncertainties ... \u001b[?25ldone\n",
+      "\u001b[?25h  Stored in directory: /home/ec2-user/.cache/pip/wheels/d9/d3/0e/5b0b743a8abd50373705427438456da5dc2621891138d7a618\n",
+      "Successfully built lmfit cerberus asteval uncertainties\n",
+      "\u001b[31mawscli 1.18.39 has requirement botocore==1.15.39, but you'll have botocore 1.15.4 which is incompatible.\u001b[0m\n",
+      "Installing collected packages: xmltodict, tqdm, psycopg2, ruamel.yaml.clib, ruamel.yaml, monty, numpy, scipy, asteval, uncertainties, lmfit, pytz, python-dateutil, pandas, cerberus, botocore, boto3, watchtower, tables, beep\n",
+      "  Found existing installation: psycopg2 2.7.5\n",
+      "    Uninstalling psycopg2-2.7.5:\n",
+      "      Successfully uninstalled psycopg2-2.7.5\n",
+      "  Found existing installation: numpy 1.14.3\n",
+      "    Uninstalling numpy-1.14.3:\n",
+      "      Successfully uninstalled numpy-1.14.3\n",
+      "  Found existing installation: scipy 1.1.0\n",
+      "    Uninstalling scipy-1.1.0:\n",
+      "      Successfully uninstalled scipy-1.1.0\n",
+      "  Found existing installation: pytz 2018.4\n",
+      "    Uninstalling pytz-2018.4:\n",
+      "      Successfully uninstalled pytz-2018.4\n",
+      "  Found existing installation: python-dateutil 2.7.3\n",
+      "    Uninstalling python-dateutil-2.7.3:\n",
+      "      Successfully uninstalled python-dateutil-2.7.3\n",
+      "  Found existing installation: pandas 0.24.2\n",
+      "    Uninstalling pandas-0.24.2:\n",
+      "      Successfully uninstalled pandas-0.24.2\n",
+      "  Found existing installation: botocore 1.15.39\n",
+      "    Uninstalling botocore-1.15.39:\n",
+      "      Successfully uninstalled botocore-1.15.39\n",
+      "  Found existing installation: boto3 1.12.39\n",
+      "    Uninstalling boto3-1.12.39:\n",
+      "      Successfully uninstalled boto3-1.12.39\n",
+      "  Found existing installation: tables 3.4.3\n",
+      "    Uninstalling tables-3.4.3:\n",
+      "      Successfully uninstalled tables-3.4.3\n",
+      "Successfully installed asteval-0.9.18 beep-2020.5.24 boto3-1.12.4 botocore-1.15.4 cerberus-1.3.2 lmfit-1.0.1 monty-3.0.2 numpy-1.18.1 pandas-1.0.1 psycopg2-2.7.7 python-dateutil-2.8.0 pytz-2019.3 ruamel.yaml-0.16.10 ruamel.yaml.clib-0.2.0 scipy-1.4.1 tables-3.6.1 tqdm-4.43.0 uncertainties-3.1.2 watchtower-0.7.3 xmltodict-0.12.0\n",
+      "\u001b[33mYou are using pip version 10.0.1, however version 20.2b1 is available.\n",
+      "You should consider upgrading via the 'pip install --upgrade pip' command.\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install beep"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## BEEP imports\n",
+    "The main modules used in the data pipeline are `validate`, `structure`, and `featurize`. Development of the `featurize` and `run_model` modules are ongoing since they represent the scientific research into the mechanisms of battery degradation and the goals of prediction.\n",
+    "The data structure uses the `MSONable` data format from `monty` which is close to json, but allows the package to store pandas dataframes with characters that are not allowed in standard json format. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "env: BEEP_ENV=dev\n",
+      "env: BEEP_PROCESSING_DIR=tutorial\n"
+     ]
+    }
+   ],
+   "source": [
+    "import requests\n",
+    "import os\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from monty.json import MSONable\n",
+    "from monty.serialization import loadfn, dumpfn\n",
+    "from scipy.stats import skew\n",
+    "from glob import glob\n",
+    "from datetime import datetime\n",
+    "import matplotlib.pyplot as plt\n",
+    "%env BEEP_ENV=dev\n",
+    "%env BEEP_PROCESSING_DIR=tutorial\n",
+    "from beep import validate, structure, featurize, run_model, generate_protocol\n",
+    "import json\n",
+    "import glob"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## File Download\n",
+    "The example data set we are using here comes from a set of A123 LFP cells cycled under fast charge conditions. While cell is configured for downloading a single cell, its also possible to download the entire data set and run all of the processing steps on all of the data. Note that for Arbin files, it is necessary to have the metadata file in addition to the data file in order to perform the data structuring correctly.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Beginning file download with requests\n",
+      "200\n",
+      "text/csv\n",
+      "ISO-8859-1\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Beginning file download with requests')\n",
+    "data_dir = './Severson-et-al/'\n",
+    "\n",
+    "try:\n",
+    "    os.makedirs(data_dir)\n",
+    "except FileExistsError:\n",
+    "    pass\n",
+    "\n",
+    "url = 'https://data.matr.io/1/api/v1/file/5c86c0bafa2ede00015ddf70/download'\n",
+    "r = requests.get(url)\n",
+    "\n",
+    "with open(os.path.join(data_dir, '2017-05-12_6C-50per_3_6C_CH36.csv'), 'wb') as f:\n",
+    "    f.write(r.content)\n",
+    "    \n",
+    "url = 'https://data.matr.io/1/api/v1/file/5c86c0b5fa2ede00015ddf6d/download'\n",
+    "r = requests.get(url)\n",
+    "\n",
+    "with open(os.path.join(data_dir, '2017-05-12_6C-50per_3_6C_CH36_Metadata.csv'), 'wb') as f:\n",
+    "    f.write(r.content)\n",
+    "\n",
+    "# Retrieve HTTP meta-data\n",
+    "print(r.status_code)\n",
+    "print(r.headers['content-type'])\n",
+    "print(r.encoding)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data pipeline\n",
+    "This cell creates a list of all of the files in the data directory and then runs the data pipeline processing steps on each of the files.\n",
+    "\n",
+    "#### Validation\n",
+    "This module determine if the data conforms to expected format with the correct column names and with values inside an expected range.\n",
+    "\n",
+    "#### Structuring\n",
+    "The structuring module turns the time series data from the cycler machine into a json-like structure with DataFrame objects. The DataFrame objects include a summary DataFrame with per cycle statistics, and a DataFrame with interpolated charge and discharge steps of the regular cycles. For files that have diagnostic cycles that were programmatically inserted, separate DataFrame objects are created with summary statistics and interpolated steps for the diagnostic cycles.\n",
+    "\n",
+    "#### Featurization\n",
+    "Featurization uses the structured objects to calculate statistically and physically relevant quantities for the purpose of building predictive machine learning models. The objects can be selected and joined for the purposes of training the model, or used for predicting individual outcomes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:01<00:00,  1.53s/it]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"file_list\": [\"./Severson-et-al/2017-05-12_6C-50per_3_6C_CH36.csv\"], \"run_list\": [0], \"validity\": [\"valid\"], \"message_list\": [{\"comment\": \"\", \"error\": \"\"}], \"mode\": \"events_off\"}\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 877/877 [01:59<00:00,  7.32it/s]\n",
+      "100%|██████████| 877/877 [02:08<00:00,  6.84it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"file_list\": [\"/home/ec2-user/SageMaker/tutorial/data-share/structure/2017-05-12_6C-50per_3_6C_CH36_structure.json\"], \"run_list\": [0], \"result_list\": [\"success\"], \"message_list\": [{\"comment\": \"\", \"error\": \"\"}], \"invalid_file_list\": [], \"mode\": \"events_off\"}\n",
+      "{\"file_list\": [\"/home/ec2-user/SageMaker/tutorial/data-share/features/DeltaQFastCharge/2017-05-12_6C-50per_3_6C_CH36_features_DeltaQFastCharge.json\", \"/home/ec2-user/SageMaker/tutorial/data-share/features/TrajectoryFastCharge/2017-05-12_6C-50per_3_6C_CH36_features_TrajectoryFastCharge.json\"], \"run_list\": [0], \"result_list\": [\"success\", \"success\"], \"message_list\": [{\"comment\": \"\", \"error\": \"\"}, {\"comment\": \"\", \"error\": \"\"}], \"mode\": \"events_off\"}\n"
+     ]
+    }
+   ],
+   "source": [
+    "data_dir = './Severson-et-al/'\n",
+    "file_list = glob.glob(os.path.join(data_dir, '*[0-9].csv'))\n",
+    "\n",
+    "mode = 'events_off'\n",
+    "mapped  =  {\n",
+    "            \"mode\": 'events_off',  # mode run|test|events_off\n",
+    "            \"file_list\": file_list,  # list of file paths ['path/test1.csv', 'path/test2.csv']\n",
+    "            'run_list': list(range(len(file_list)))  # list of run_ids [0, 1]\n",
+    "            }\n",
+    "mapped = json.dumps(mapped)\n",
+    "# Validation\n",
+    "validated = validate.validate_file_list_from_json(\n",
+    "    mapped)\n",
+    "validated_output = json.loads(validated)\n",
+    "validated_output['mode'] = mode  # mode run|test|events_off\n",
+    "validated_output['run_list'] = list(range(len(validated_output['file_list'])))\n",
+    "validated = json.dumps(validated_output)\n",
+    "\n",
+    "print(validated)\n",
+    "\n",
+    "# Data structuring\n",
+    "structured = structure.process_file_list_from_json(\n",
+    "    validated)\n",
+    "structured_output = json.loads(structured)\n",
+    "structured_output['mode'] = mode  # mode run|test|events_off\n",
+    "structured_output['run_list'] = list(range(len(file_list)))\n",
+    "structured = json.dumps(structured_output)\n",
+    "\n",
+    "print(structured)\n",
+    "\n",
+    "# Featurization\n",
+    "featurized = featurize.process_file_list_from_json(\n",
+    "    structured)\n",
+    "featurized_output = json.loads(featurized)\n",
+    "featurized_output['mode'] = mode  # mode run|test|events_off\n",
+    "featurized_output['run_list'] = list(range(len(file_list)))\n",
+    "featurized = json.dumps(featurized_output)\n",
+    "\n",
+    "print(featurized)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interpolated cycles\n",
+    "The code below demonstrates how to access the DataFrame objects in the structure file. Loading the file is substantially faster than analyzing the raw time series data. The interpolated data also provides the ability to calculate differences between cycles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4.6974263191223145\n",
+      "876\n",
+      "1.1737735\n",
+      "1.1737735\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x7f35e86beb70>]"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD8CAYAAACMwORRAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3Xl43Fd97/H3V6PNkkaSrd22ZHmRvMRJ7MR24kDIHkxKk7aUEErYmjYQ+tzL0tJeyi1PCe3thdub3tLCA2lpE9JSspRSF0ggBIesdmwn3ncrtmXLWq19Gc1y7h8zUhQhWWN7RrN9Xs+jRyPNkeZ7JM1njs7v/M7PnHOIiEh6yUp0ASIiEnsKdxGRNKRwFxFJQwp3EZE0pHAXEUlDCncRkTSkcBcRSUMKdxGRNKRwFxFJQ9mJeuDy8nJXX1+fqIcXEUlJO3fu7HTOVczULmHhXl9fz44dOxL18CIiKcnMTkbTTtMyIiJpSOEuIpKGFO4iImlI4S4ikoYU7iIiaWjGcDezfDN7zcx2m9l+M/vyNO3uNrMDkTbfi32pIiISrWiWQvqAm51zA2aWA7xkZk8757aONTCzBuALwDucc91mVhmnekVEJAozhrsLX4dvIPJhTuRt8rX5fh/4hnOuO/I17bEsUkQkFQSCIX64q4XT3UO/cl+WGZ4sI8djvHNZBavmF8e1lqhOYjIzD7ATWEY4xLdNatIYafcy4AH+3Dn3zBTf537gfoC6urpLKFtEJPl865fH+eufHZmx3V/+ZnZyhLtzLgisMbNS4D/MbLVzbt+k79MA3AgsBF4ws8udcz2Tvs/DwMMA69at05W5RSSt/HR/G1fWlvKDB64jy8A5MAvfF3LgD4YIhBw5Hot7LRe0WiYS1luATZPuOg1sds75nXNvAkcIh72ISEZo7x9h75lebltZiSfLMDOyIu8tMiWTn+OhKC+bvGxP3OuJZrVMRWTEjpnNAW4DDk1q9kPCo3bMrJzwNE1TTCsVEUliWw6FDzXesrIqwZWERTNyrwG2mNkeYDvwrHPuR2b2oJndGWnzU6DLzA4QHtl/3jnXFZ+SRSRTOOfYcridzbtbEl3KjH5+sJ0FpXNYUe1NdClAdKtl9gBrp/j8lybcdsDnIm8iaaej30ffiJ+lFUWJLiUj+AJB/nNXC//wQhNH28OL9VbPL2ZJkv78R/xBXjrayfvXLcQs/vPp0UjYlr8iyWg0EOJ4xwCHWvs41NrPobP9HDzbR3u/DzPY+oVbqCrOT3SZaauj38e/vXaKf9l6kvZ+HyuqvXx04yIeffUkJ7uGkjbcXzraybA/yM0rkucUH4W7ZCTnHG19Pg629nHobD+HI2F+rH2AQCi8kCvXk8WyyiLe2VBOIOjYvLuFvmG/wj3GQiHHtjfP8fj2U/xkbyujwRDXN5Tz1++/kusbytl7ppdHXz1JMJS8C+x+uOsM8wpzecey8kSXMk7hLmlvaDTAkbYBDp2NjMYjQd4z5B9vs6B0Dsurvdy8opIVNcWsrPZSX15Ijid8WOqZfWfZvLtlPPjl0p3tHeapHad5cudpTp0bwpuXze9cU8eHNy562/RXVmSaI+SS82ffP+Ln2QNt3LO+dvzvJRko3CVthEKO5u4hDp6NBPjZfg639XOia5CxXCjM9bC82st7VtewssbLiupilld7KZmTc97v7ckKP2mTefSYCnyBIM8dbOfx7c28eLSDkIONS8r47G0NbLqshjm5v7pEMNnD/Zl9rfgCIe5auyDRpbyNwl1SUu+Q/6158dY+Dp7t50hbP0OjQSB84sjiskJW1nj5jTULWFHjZWV1MQvnziEr68IPeGVHvkYj9wsXDDm2NXWxeXcLT+9rpXfYT01JPn9w0zLef3UtdWUF5/36yOsqyfqj/+GuMywqK2BtbWmiS3kbhbskNX8wxJudgxwcm1KJvD/bOzLeprQgh5XVxXxgfS0rqsOj8cYq75SjwIvliYR7MBSK2fdMZ845djX3sHl3Cz/ec5b2fh8FuR5uX1XFb6xdwPUNFeM/05l4bOxnn3zpfqJzkFeOd/HpWxqSZpXMGIW7JAVfIMiJziGOtvdztG2AY+0DHG3v583OQfzB8JM6x2MsrSji2iVlrKj2srzay8qaYiq9eXF/Yo2P3IPJFzDJwh8Msa3pHD870MrPD7TR0jtCrieLm1ZUcOeVC7h5ReVFveCO/aeVjNMyj209iceMD25Ivr2yFO4yq0b8QZo6BjnaHl6ZcrRtgCPt/ZzsGhofmWUZ1M0roKHKyy0rq8aDfEl5EbnZiTlg9dbIPfkCJpH6R/z88kgHzx5o4xeH2ukfCZCfk8X1DRV89rZG3r26muL88x/PmEmyzrkPjQZ4Ykczm1ZXJ+UKKoW7xMXwaJDjHQPjI/EjbQMca+/n1Lmh8blTT5ZRX1ZAY6WXX7u8hmWVRTRUellSUUh+Tvz33rgQ2R7NuUN4uuXNzkFePtbJzw+28+rxLkaDIeYV5rLpsmpuW1XF9Q0VsZ0SGwv3JJsRe3x7M/0jAT52XX2iS5mSwl0uydBogGPt4fAeC/Kj7f2c7h4eX6GS4zEWlxdy2fwS7lqzgIaqcIjXlxfMygZKsZDJq2VaeoZ55XgXrxzr5JXjXbT2hY93LCor4CMbF3H7ZdVcvWhu1HPoF2psxi2YRCP3EX+Qb/3yOBsWz2Nd/bxElzMlhbtEZTQQPrB5uK2fI63hJYZH2sIj8bHnXK4niyUVhaypncv7r66lobKIhqoiFpUVJtX634uRSatlugZ8vNrUNR7oJ7rCF56YV5jLxiVlXLesjI1LylhcXjgrBxHHXjRcEoX749ubaevz8Td3r0l0KdNSuMvbjK0VP9zaH36LhHhTx+B4sHmyjCXlhaxeUML7rlpIY5WXxqoi6uYVkJ3iIT6ddF4t0zfi57Wmc+EwP97JodZ+ALx52VyzZB4f3ljPdUvLWF7lvahlpJcqa3y1zKw/9JT6Rvx8/bmjbFg8j41LyxJdzrQU7hns3OAoB8/2caClbzzEj7T1M+J/61lUO28Oy6u83LqyiuXVXhqrwnPiqTKdEivpMnJ3znG6e5jXT3XzxqkeXj/Vzf6WPoIhR152Fuvr5/H5d8/nuqVlXL6gJClerN9a554cP/u/e+4o54ZGeeTXViXd8seJFO4ZIBhynOgaHA/yg2fDJ/2MzZ0CVHjzWFHt5UPXLGJ5lZfGai8NlUUU5ulPBFJ3tUzngI99Z3rZ39LH7uYeXj/VQ+eAD4A5OR6urC3hUzcu5bql5Vy1qDQpX7STabVMU8cAj7xygvdfvZDLF5Ykupzz0jM3zfiDIY609bPvTC97Toef1Idb+xn2h8/czM4yllUWsXFpGatqillZU8zKGi9lRXkJrjy5ZUeGj8m6zt05x9nekfEg39/Sy74zfW97Aa8vK+BdDeWsXTSXtbWlrKj2JsXIfCZvrZZJ7M8+GHJ8/qk95Od4+KN3L09oLdFQuKewUMjR1DnI66e62XO6h72neznY2s9oIDyt4s0LX4T3ng2140HeUFWUlKOzZOfxJM/IPRRynDo3xL6WcJCPBfq5wVEgfJ7A0orwC/hl84u5bH4Jq+YXz7h/TrIan3NP8I/+Oy81sfNkNw/dfSWV3uRb1z6Zwj2FBIIhdp/u4eVjXew82c2u5h56h8M7G3rzsrlsQTEfu66e1QtKuHxBCYvmFSTkAFg6Gptz/6eX3+TJnc38r9+8nIaq+F9xJxAM0dQ5OD4S33emlwMtffT7AkB4mWljlZfbVlZx2YJwkK+s8VKQmz5P7bE590Sultnd3MNf/+wIt62q4jeTbIOw6aTPX0AaGjth5KVjnbx4tJOtx7vo9wUwg4bKIt6zupqr6uZy1aJSlpQXKcjjaGzOfWwlyd3ffpWHPrCGGxsrYnJQLRhynOwaDJ8v0NbPkfbw+6aOQUYjy0Tyc7JYUV3MXWvns3p+CasXlGTEf2KJPt7R3j/CJx7bSaU3j6++74qkPog6kcI9yfgCQV453sXP9rfywpFOzvQMA7Bw7hzee2UN71xWwXVLy5hbmJvgSjNL9oQXznuvreOlo518/J+3s7aulI9sXMTNy6soKTj/tMfQaID2Ph9tfSOcPDfEic5B3oy8NXUOjk+nQfj33Vjl5YblFSyv8rJ6QQlLygtTYo481t46oDr7jz0aCPGpf3mdnuFRfvDAO5iXQs87hXsSGBoN8MvDHTyzv5VfHGyn3xegKC+bdy4r54Ebl3J9QzmLygoTXWZGm3j25T3r6/iz967iqZ2n+eaW43z28d2YQXVxPgvnzqEgNxtPljHiDzLiD9Iz7Kejzzc+lTImO8uom1dAfXkhNzRWsKyyiMYqL8u0SultErVaJhAM8dkndrHjZDd/98G1rJpfPKuPf6n0F5Qg/mCIF4928MM3WvjZgVZG/CHmFuRwx+U1bFpdzXXLytL+3+1UMrZaBmBVTTFZWcaHrlnEB9fXsft0Dy8e7eRE1yAtPcP0DI0SCDnm5HgoyM2mpmQO72rIo7I4j0pvPpXePBaVFbCgdE5GjsQv1Njr6myulgmFHH/873v48Z6zfOE9K/j1K+fP2mPHisJ9lrX0DPO9baf4/vZTdA6MUlqQw29dtZD3XlHDhvp5erInqYkj96xJt9fWzWVt3dxElJURxufcZ2nkPuIP8kdP7uZHe87y2Vsb+cQNS2flcWNN4T4LnHNsbTrHd189wc8OtBFyjltWVPKB9XXc0FiRsG1sJXo5HuOOy6v5rbULE11KxrFZnHPv6Pdx/2M7eONUD3+yaQWfvGFJ/B80ThTuceQPhviPN87wjy82caRtgNKCHH7v+sXce80iaued/9JiklzMjG9+6OpEl5GxPFkW92mZw639/O4j2+ka9PGte69i0+qauD5evCnc42DEH+TJnaf51vPHOdMzzMqaYr7221dw55Xzk26fcpFUkGXxPaD69N6zfP6pPRTkenjiExu5YmFyXQ/1YijcY2hoNMD3tp3i4ReaaO/3cVVdKX/xG6u5cXls1kKLZKoss7jMuXcPjvKlzfv5r90tXLGwhG9/+GpqSubE/HESQeEeAwO+AI+8/CbfeelNuof8XLe0jP93zxo2LilTqIvEgCfLiGW2O+d4Zl8rf/af++kdHuUPb2vkkzcuTfnrDkykcL8E/mCI729v5m9/foTOgVFuXlHJH9y0jKsXaeWESCxlmcXsDNWDZ/v4yo8O8MrxLlbVFPPYfRtYWZNaa9ijoXC/CM45frq/ja89c4imzkE2LJ7HP3xkhZbDicRJLObcz/QM8/e/OMrj25spnpPDl++8jA9dU5e2y48V7hfoWHs/f775AC8d66SxqojvfHQdN6+o1PSLSBxlXcJqmdPdQ3zz+eM8uaMZgI9srOcztzZQWpA6WwlcDIV7lIZGA/ztz4/ynZfepCDXw4N3XcbvbEjfV32RZOK5iAOqk0P97nW1fOqmZSwoTY8DpjNRuEdh+4lz/NGTuznZNcQH1tXyx5uW6+IWIrPIzKI+iel09xDf2HKcp3aGQ/0D62t54MbMCfUxCvfzGPEHeejZI/zDi00snDuHx++/lmuWJO8FcUXSlSdr5r1lms8N8c3nj/HkjtNkmXHP+joeuHEp8zMs1Mco3KfRfG6I+x7dzpG2AT50TR1/esdK7dQnkiBZZtMeUO0ZGuXrzx3jsa0nMIzfuSYc6umyXv1iKa2msOd0D7/7yHb8QccjH1/PjcsrE12SSEbL8WS9bb97CF/74LFXT/L1544y4Atw97paPn1rQ8aH+hiF+yRbDrXzqX99nbKiXL5//waWVRYluiSRjFeUl83AhP3wdzX38LkndtHUMcgNjRV84Y4VrKhOv7Xql0LhPsH2E+f4xL/spLGqiH/62PqUuAiuSCYoys+mfySAc45/fPFN/vczh6jy5vHPH1/PTfrPekozruMzs3wze83MdpvZfjP78nnavs/MnJmti22Z8XesfYDfe3QHC0vn8N3fvUbBLpJEvHnhcP/yfx3gL39ykNtXVfH0Z96lYD+PaEbuPuBm59yAmeUAL5nZ0865rRMbmZkX+DSwLQ51xtXQaID7v7uDHI/xyMc3pNR1EkUyQVF+NgcO9XHgbB/3vXMxX7xjpS4IP4MZR+4ubCDyYU7kbarD1l8BvgqMxK682fFXPwlvI/D1D66lrkz7rIskm7M94Vi5a818/uevKdijEdXplWbmMbNdQDvwrHNu26T7rwJqnXM/jkONcbXzZDePbT3Jfe9czHVLyxNdjohM4b1Xhi+c8eCdq7XVR5SiOqDqnAsCa8ysFPgPM1vtnNsHYGZZwEPAx2b6PmZ2P3A/QF1d3cXWHDPOOf7qJwep8Obxh7c3JrocEZnGRzbWc+81izRivwAXtDGKc64H2AJsmvBpL7AaeN7MTgDXApunOqjqnHvYObfOObeuoqLi4quOkWcPtLHjZDefubWBglwtHBJJZgr2CxPNapmKyIgdM5sD3AYcGrvfOdfrnCt3ztU75+qBrcCdzrkdcao5JpxzPPTsEZZUFPKBdbWJLkdEJKaiGbnXAFvMbA+wnfCc+4/M7EEzuzO+5cXP66e6OdTazyfetUQ7O4pI2plxLsI5twdYO8XnvzRN+xsvvaz4+962ZorysnnvFfMTXYqISMxl5JC1d9jPj/e2cNea+doMTETSUkaG++ZdZxjxh/jghsSv2BERiYfMDPfdLayo9rJ6QUmiSxERiYuMC/e2vhF2nOzmPatrEl2KiEjcZFy4/3R/K87BHZdXJ7oUEZG4ybhw/8nesyyrLKKhypvoUkRE4iajwr132M/2E93cvqoq0aWIiMRVRoX7y8c6CYYcN63QHtAikt4yKtyfP9yONz+btbWliS5FRCSuMibcnXP88kgH1zeUa7sBEUl7GZNyh1r7aevzcWOjpmREJP1lTLj/8kgHAO9qTPxWwyIi8ZYx4f7ysU4aq4qoLtGFr0Uk/WVEuPuDIXac6GbjkrJElyIiMisyItz3nO5l2B/kWoW7iGSIjAj3rU1dAGxYPC/BlYiIzI6MCfflVV7KivISXYqIyKxI+3Afm2+/dolG7SKSOdI+3PeeCc+3X6P5dhHJIGkf7q+f7AZg3aK5Ca5ERGT2pH2472ruYX5JPpXFWt8uIpkjI8J9TZ02ChORzJLW4d454ON09zBrtAukiGSYtA733c09AKyp1Xy7iGSWtA73Xc09eLKMyxeUJLoUEZFZlfbhvrzKy5xcT6JLERGZVWkb7qGQ08FUEclYaRvuTZ2D9I8EdDBVRDJS2ob784fbAVhfr20HRCTzpG24P7XzNGtqS1lcXpjoUkREZl1ahrsvEORQaz83Ldf1UkUkM6VluHcNjAJQWawtfkUkM6VluHf0+wAo1/7tIpKh0jzccxNciYhIYqRluDd1DgDoYKqIZKy0DPfDrQNUFedRWqCRu4hkpvQM97Y+Gqu8iS5DRCRh0i7cfYEgR9sGWK5wF5EMNmO4m1m+mb1mZrvNbL+ZfXmKNp8zswNmtsfMnjOzRfEpd2avHOvCFwjxjmXliSpBRCThohm5+4CbnXNXAmuATWZ27aQ2bwDrnHNXAE8BX4ttmdF79mAbRXnZXLdMF8QWkcw1Y7i7sIHIhzmRNzepzRbn3FDkw63AwphWeQGazw3RUFVEXra2+RWRzBXVnLuZecxsF9AOPOuc23ae5vcBT8eiuItxbnCUuVolIyIZLqpwd84FnXNrCI/IN5jZ6qnamdm9wDrg/0xz//1mtsPMdnR0dFxszefVrXAXEbmw1TLOuR5gC7Bp8n1mdivwReBO55xvmq9/2Dm3zjm3rqKi4mLqndG5oVHmFebE5XuLiKSKaFbLVJhZaeT2HOA24NCkNmuBbxMO9vZ4FBqN3iE/I/4QFV7tKSMimS07ijY1wKNm5iH8YvCEc+5HZvYgsMM5t5nwNEwR8KSZAZxyzt0Zr6Knc6wjfNx3SXnRbD+0iEhSmTHcnXN7gLVTfP5LE27fGuO6LkpTJNyXVircRSSzpdUZqsc7BsnxGLVz5yS6FBGRhEqzcB9gUVkh2Z606paIyAVLqxRs6hhgaYW2+RURSZtw9wdDnOwaYkmF5ttFRNIm3JvPDREIOZYq3EVE0ifcj3cMArBE0zIiIukT7md7hwFYqJUyIiLpE+4d/T6yDMoKdXaqiEhahfu8wjw8WZboUkREEi5twr21b0R7yoiIRKRFuDvn2N3cw+r5xYkuRUQkKaRFuHcP+eke8rOyRuEuIgJpEu6dA+Ht4zUtIyISllbhXl6kcBcRgbQJ91EAyot0eT0REUiTcD/S2o8ny1igE5hERIA0Cff9Lb00VnkpyI3mwlIiIukvLcK9e8ivKRkRkQnSItz7RvwUz8lJdBkiIkkjLcK9fyRAcb6mZERExqRFuPcN+ynO18hdRGRMyoe7LxDEFwhpWkZEZIKUD/fuQT8ApQUKdxGRMSkf7m19IwBUevMTXImISPJI+XBv7w9vPVBVrK0HRETGpHy4j11er6pYI3cRkTEpH+5H2vrx5mdTqR0hRUTGpXy4H2sfoLHKi5kuryciMiblw7353DCL5hUkugwRkaSS0uHuD4Y42zvMQoW7iMjbpHS4t/QME3KwUFv9ioi8TUqH++nu8EqZ2rkauYuITJTi4T4EaOQuIjJZSod773B464G5hdrLXURkopQO90FfEICCHE+CKxERSS4pHu4BCnM9ZGVpjbuIyESpHe6jAQrydJEOEZHJUjvcfUGKFO4iIr9ixnA3s3wze83MdpvZfjP78hRt8szscTM7ZmbbzKw+HsVONugLUJin+XYRkcmiGbn7gJudc1cCa4BNZnbtpDb3Ad3OuWXA3wBfjW2ZUxvwBSjI1chdRGSyGcPdhQ1EPsyJvLlJze4CHo3cfgq4xWZhJ6+hUU3LiIhMJao5dzPzmNkuoB141jm3bVKTBUAzgHMuAPQCZbEsdCqDvgAFuZqWERGZLKpwd84FnXNrgIXABjNbfTEPZmb3m9kOM9vR0dFxMd/ibQZ8AY3cRUSmcEGrZZxzPcAWYNOku84AtQBmlg2UAF1TfP3Dzrl1zrl1FRUVF1fxBEOjQQoV7iIivyKa1TIVZlYauT0HuA04NKnZZuCjkdu/DfzCOTd5Xj6mnHMMjoZPYhIRkbeLZthbAzxqZh7CLwZPOOd+ZGYPAjucc5uB7wCPmdkx4BxwT9wqjhgaDeIcGrmLiExhxmR0zu0B1k7x+S9NuD0CvD+2pZ3foC8AKNxFRKaSsmeoju0IWTInJ8GViIgkH4W7iEgaStlw7xlSuIuITCdlw10jdxGR6aVsuJ/sGgR0FSYRkamkbLi/2tTF2rpSjdxFRKaQsuE+7A9SplG7iMiUUjbcR/wh8rJ1dqqIyFRSNtx9gSB52SlbvohIXKVsOvr8IfJyUrZ8EZG4Stl09AU0LSMiMp0UDndNy4iITCcl09E5FzmgmpLli4jEXUqm42gwBEBejqZlRESmkpLh7gtEwl0jdxGRKaVkOvr8CncRkfNJyXQcu1BHQa4u1CEiMpWUDPe+kfCOkMXaV0ZEZEopGe79I+GRuzdfI3cRkamkaLhHRu75GrmLiEwlJcP9v39/F6CRu4jIdFIy3EcjSyF1oQ4Rkaml5NC3piQfb342RXkpWb6ISNyl7Mh9ff28RJchIpK0UjLcB0cDGrWLiJxHyoV7IBhixB/SCUwiIueRcuE+5A8CUJinTcNERKaTeuHuC4e7Ru4iItNLuXD3R7b7zdWmYSIi00q5hAyEHACelKtcRGT2pFxEBkPhkbsnK+VKFxGZNSmXkJFZGbKzLLGFiIgksZQL90Bk5J5lCncRkemkXLiHNHIXEZlRyoX72Mjd41G4i4hMJ+XCPTi2WkbTMiIi00rZcNe0jIjI9FI23LMU7iIi05ox3M2s1sy2mNkBM9tvZp+eok2Jmf2Xme2OtPl4fMp96yQmjdxFRKYXzQYtAeAPnXOvm5kX2GlmzzrnDkxo8wfAAefcr5tZBXDYzP7VOTca64KDbuwMVYW7iMh0Zhy5O+fOOudej9zuBw4CCyY3A7xmZkARcI7wi0LMBYMKdxGRmVzQnLuZ1QNrgW2T7vp7YCXQAuwFPu2cC03x9feb2Q4z29HR0XFRBWvkLiIys6jD3cyKgH8HPuOc65t097uBXcB8YA3w92ZWPPl7OOceds6tc86tq6iouKiCx5dCKtxFRKYVVbibWQ7hYP9X59wPpmjyceAHLuwY8CawInZlvkUHVEVEZhbNahkDvgMcdM49NE2zU8AtkfZVwHKgKVZFThQaH7mn3CpOEZFZE81qmXcAHwb2mtmuyOf+FKgDcM59C/gK8IiZ7QUM+BPnXGcc6n1rP3edoSoiMq0Zw9059xLhwD5fmxbg9lgVdT7jI3ftLSMiMq2Um9vQnLuIyMxSLtyD2s9dRGRGKRjuGrmLiMwk5cI9oI3DRERmlHLhrpG7iMjMUi7cF5cXcsfl1WRrtYyIyLSiWeeeVG6/rJrbL6tOdBkiIkkt5UbuIiIyM4W7iEgaUriLiKQhhbuISBpSuIuIpCGFu4hIGlK4i4ikIYW7iEgaMhe54PSsP7BZB3DyIr+8HIjLxUCSTCb0MxP6CJnRz0zoIyS+n4ucczNehDph4X4pzGyHc25douuIt0zoZyb0ETKjn5nQR0idfmpaRkQkDSncRUTSUKqG+8OJLmCWZEI/M6GPkBn9zIQ+Qor0MyXn3EVE5PxSdeQuIiLnkdThbmabzOywmR0zs/8xxf15ZvZ45P5tZlY/+1Vemij6+DkzO2Bme8zsOTNblIg6L9VM/ZzQ7n1m5sws6VcjTCWafprZ3ZHf6X4z+95s13ipovibrTOzLWb2RuTv9o5E1HkpzOyfzKzdzPZNc7+Z2dcjP4M9ZnbVbNc4I+dcUr4BHuA4sATIBXYDqya1+RTwrcjte4DHE113HPp4E1AQuf1AqvUx2n5G2nmBF4CtwLpE1x2n32cD8AYwN/JxZaLrjkMfHwYeiNxeBZxIdN0X0c93AVcB+6a5/w7gacCAa4Ftia558lsyj9w3AMecc03OuVHg+8Bdk9rcBTwauf0UcIuZpdL192bso3Nui3NuKPLhVmDhLNdhyE9gAAACcElEQVQYC9H8LgG+AnwVGJnN4mIomn7+PvAN51w3gHOufZZrvFTR9NEBxZHbJUDLLNYXE865F4Bz52lyF/BdF7YVKDWzmtmpLjrJHO4LgOYJH5+OfG7KNs65ANALlM1KdbERTR8nuo/waCHVzNjPyL+1tc65H89mYTEWze+zEWg0s5fNbKuZbZq16mIjmj7+OXCvmZ0GfgL8t9kpbVZd6HN31qXcNVQzlZndC6wDbkh0LbFmZlnAQ8DHElzKbMgmPDVzI+H/wl4ws8udcz0JrSq2Pgg84pz7v2a2EXjMzFY750KJLiyTJPPI/QxQO+HjhZHPTdnGzLIJ/wvYNSvVxUY0fcTMbgW+CNzpnPPNUm2xNFM/vcBq4HkzO0F4DnNzCh5Ujeb3eRrY7JzzO+feBI4QDvtUEU0f7wOeAHDOvQrkE96PJZ1E9dxNpGQO9+1Ag5ktNrNcwgdMN09qsxn4aOT2bwO/cJGjHSlixj6a2Vrg24SDPdXmZ8ect5/OuV7nXLlzrt45V0/42MKdzrkdiSn3okXzN/tDwqN2zKyc8DRN02wWeYmi6eMp4BYAM1tJONw7ZrXK+NsMfCSyauZaoNc5dzbRRb1Noo/oznDE+g7CI5vjwBcjn3uQ8BMfwn80TwLHgNeAJYmuOQ59/DnQBuyKvG1OdM3x6Oekts+Tgqtlovx9GuEpqAPAXuCeRNcchz6uAl4mvJJmF3B7omu+iD7+G3AW8BP+b+s+4JPAJyf8Hr8R+RnsTca/V52hKiKShpJ5WkZERC6Swl1EJA0p3EVE0pDCXUQkDSncRUTSkMJdRCQNKdxFRNKQwl1EJA39fxNrLxd1qxd8AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "processing_dir = %env BEEP_PROCESSING_DIR\n",
+    "struct = loadfn(os.path.join(processing_dir, 'data-share', 'structure', '2017-05-12_6C-50per_3_6C_CH36_structure.json'))\n",
+    "reg_charge = struct.cycles_interpolated[struct.cycles_interpolated.step_type == 'charge']\n",
+    "print(reg_charge.current[reg_charge.cycle_index == 25].mean())\n",
+    "print(reg_charge.cycle_index.max())\n",
+    "print(reg_charge.charge_capacity[reg_charge.cycle_index == 25].max())\n",
+    "print(reg_charge.charge_capacity[reg_charge.cycle_index == 600].max())\n",
+    "plt.plot(reg_charge.charge_capacity[reg_charge.cycle_index == 600], reg_charge.voltage[reg_charge.cycle_index == 600])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Summary data\n",
+    "The summary data provides a quick way of determine how the battery cell degrades during the cycling experiment. Quantities such as energy efficiency per cycle and total charge throughput at a given cycle number are calculated."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x7f35f91d7828>]"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD8CAYAAACMwORRAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAHY5JREFUeJzt3Xt8VGe97/HPLzO530kCBJIAAVouLaWQItSWVuulVre02mqxbi9VcW/vbj3n2KNbt1Zfbi+nbj1HW7u7a62XWq29WYtuW1vRXpBQoKXc7yTcEkIScs/MPOePmUnDZWWlMCGs4ft+vfJiZtZirWcWi2+e+c2znmXOOUREJL1kjHYDREQk9RTuIiJpSOEuIpKGFO4iImlI4S4ikoYU7iIiaUjhLiKShhTuIiJpSOEuIpKGwqO14/Lycjd58uTR2r2ISCCtXr262TlX4bfeqIX75MmTqa+vH63di4gEkpntHs56KsuIiKQhhbuISBryDXczu9vMDpnZeo/lS8zsRTNba2b1ZnZZ6pspIiKvxnB67vcAVw+x/EngIufcXOBm4K4UtEtERE6Db7g751YALUMs73CvTAqfD2iCeBGRUZaSmruZXWdmm4DfE++9i4jIKEpJuDvnHnLOzQCuBW71Ws/MliXq8vVNTU2p2LWIiJxESkfLJEo4tWZW7rH8TudcnXOurqLCdwz+SW05eJTb/nszzR29p9NUEZG0dtrhbmbTzMwSj+cB2cDh092ul60HO/jBn7fR0tk3UrsQEQk83ytUzew+4Eqg3MwagK8AmQDOuTuAdwLvM7N+oBt4tzsDd93Wfb1FRLz5hrtzbqnP8m8B30pZi3zEPyOIiMhQAnuFqtOISxERT4ELd3XcRUT8BS7ck1RzFxHxFrhwV81dRMRf4MI9ST13ERFvAQx3dd1FRPwEMNzjNFpGRMRb4MJdNXcREX+BC/ck1dxFRLwFLtzVcRcR8Re4cBcREX+BC/fEBJQqy4iIDCF44T7aDRARCYDAhXuShkKKiHgLXLhrKKSIiL/AhXuSau4iIt4CF+7quYuI+AtcuCep4y4i4i1w4W4aLyMi4itw4Z50Bu7BLSISWMELd3XcRUR8BS/cE9RvFxHxFrhwV8ddRMRf4MI9SSV3ERFvgQt300B3ERFfgQv3V6jrLiLiJXDhrn67iIi/wIV7kmruIiLeAhfuKrmLiPgLXLgnqeMuIuItcOGuuWVERPwFLtyTVHMXEfHmG+5mdreZHTKz9R7LbzKzF83sJTN71swuSn0zB+9vJLcuIpIehtNzvwe4eojlO4ErnHMXArcCd6agXb40K6SIiLew3wrOuRVmNnmI5c8Oevo8UHX6zfKmjruIiL9U19w/BCxP8TZPSv12ERFvvj334TKz1xEP98uGWGcZsAygpqbmFHd0an9NRORckpKeu5nNAe4CljjnDnut55y70zlX55yrq6ioOK19quQuIuLttMPdzGqAB4F/dM5tOf0m+ewv0XV3KsyIiHjyLcuY2X3AlUC5mTUAXwEyAZxzdwBfBsqAHyWm44045+pGqsEaCiki4m84o2WW+iz/MPDhlLVouNRxFxHxFLgrVNVxFxHxF7hwT1LHXUTEW+DCXbfZExHxF7hwT9JQSBERb4ELd3XcRUT8BS7ckzTOXUTEW+DCXR13ERF/gQv3JNXcRUS8BS7cVXMXEfEXuHBPUsddRMRbAMNdXXcRET8BDPc43WZPRMRb4MJdNXcREX+BC/ck9dtFRLwFLtzVcRcR8Re4cB+grruIiKfAhbtmhRQR8Re4cE/S3DIiIt4CF+7qt4uI+AtcuCdpmLuIiLfAhbtK7iIi/gIX7knquYuIeAtcuJuq7iIivgIX7knquIuIeAtcuKvmLiLiL3DhnqRZIUVEvAU33Ee7ASIiZ7HAhbvKMiIi/gIX7kmqyoiIeAtcuGsopIiIv8CF+yvUdRcR8RK4cFfNXUTEn2+4m9ndZnbIzNZ7LJ9hZs+ZWa+ZfT71TTw51dxFRLwNp+d+D3D1EMtbgE8B301Fg/yo5y4i4s833J1zK4gHuNfyQ865VUB/KhvmRx13ERFvwau5a7SMiIivMxruZrbMzOrNrL6pqem0tqWau4iItzMa7s65O51zdc65uoqKilPahmruIiL+AleWSdINskVEvIX9VjCz+4ArgXIzawC+AmQCOOfuMLPxQD1QBMTM7DPALOdc+0g0WB13ERF/vuHunFvqs/wAUJWyFg2Tau4iIt4CV5ZRzV1ExF/gwj1JHXcREW8BDHd13UVE/AQw3ON0mz0REW+BC3fV3EVE/AUu3EVExF/gwl0ddxERf4EL9ySV3EVEvAUu3E1FdxERX4EL9yTNLSMi4i1w4a5+u4iIv8CFe5Jq7iIi3gIX7smSu8JdRMRb8MJdhRkREV+BC/ckddxFRLwFLtw1ElJExF/gwj1JE4eJiHgLbLiLiIi3wIa7+u0iIt4CF+6quYuI+AtcuA9Q111ExFPgwl0Th4mI+AtcuCdp4jAREW+BC3f120VE/AUu3JM0zF1ExFvgwl0ldxERf4EL9yR13EVEvAUu3DUrpIiIv8CFe5Jq7iIi3gIX7qq5i4j4C1y4J2mcu4iIt8CFuzruIiL+fMPdzO42s0Nmtt5juZnZD8xsm5m9aGbzUt/ME6nmLiLibTg993uAq4dY/hZgeuJnGXD76TdrCOq6i4j48g1359wKoGWIVZYA97q454ESM6tMVQM92zXSOxARCbBU1NwnAnsHPW9IvDYiNM5dRMTfGf1C1cyWmVm9mdU3NTWd3sZUdBcR8ZSKcG8Eqgc9r0q8dgLn3J3OuTrnXF1FRcUp7Uzj3EVE/KUi3B8F3pcYNbMQaHPO7U/BdoekfruIiLew3wpmdh9wJVBuZg3AV4BMAOfcHcDjwDXANqAL+OBINRY0WEZEZDh8w905t9RnuQM+nrIWDZNK7iIi3oJ3hWqi6O6U7iIinoIX7qPdABGRAAhcuCep3y4i4i1w4a6hkCIi/gIX7kkquYuIeAtcuGv6ARERf4EL9yR13EVEvAUv3NVxFxHxFbxwT9A4dxERb4ELd42WERHxF7hwFxERf4ELd3XcRUT8BS7ck1RyFxHxFrhwNxXdRUR8BS7ck5xGuouIeApcuKvfLiLiL3DhnqSau4iIt8CFu0ruIiL+AhfuSeq4i4h4C1y4a1ZIERF/gQv3JNXcRUS8BS7cVXMXEfEXuHBP0jh3ERFvgQ13ERHxFthwV81dRMRb4MJdNXcREX+BC3cREfEXuHBPjnPXbfZERLwFLtxFRMRf4MI9WXNXx11ExFvwwn20GyAiEgCBC/ckddxFRLwNK9zN7Goz22xm28zsCydZPsnMnjSzF83saTOrSn1TB/Y1UpsWEUkbvuFuZiHgh8BbgFnAUjObddxq3wXudc7NAb4GfDPVDT2eau4iIt6G03NfAGxzzu1wzvUBvwKWHLfOLODPicdPnWR5yqjfLiLibzjhPhHYO+h5Q+K1wdYB70g8vg4oNLOy02+eN00cJiLiLVVfqH4euMLM1gBXAI1A9PiVzGyZmdWbWX1TU9Mp7UgldxERf8MJ90agetDzqsRrA5xz+5xz73DOXQx8MfFa6/Ebcs7d6Zyrc87VVVRUnEazVXMXERnKcMJ9FTDdzKaYWRZwI/Do4BXMrNzMktu6Bbg7tc08Zl8jtWkRkbThG+7OuQjwCeCPwEbg1865l83sa2b29sRqVwKbzWwLMA74xgi195V2jfQOREQCLDyclZxzjwOPH/falwc9fgB4ILVNExGRUxXYK1RVdBcR8RbIcFfZXURkaIEMd4jX3J1zNB3t5UhnH9198ZGXz25rpr2nf3QbJyIyyoZVcz/bOAf/98/b+PGKHfRFYgOv52eF6EyE/OXTyynOzaS5o5dFteU4HJPL8plcns+4omzG5Gdx38o9PPBCAx+7chpXzRxLhhmZocD+vhMRGRDIcC/Ny6Q/6li6oJrxxblkGHT1RWk40sXq3UcoL8jmaE+Ejfvbae7o4/kdLUNu73/8Zh3d/VGqx+TxwUsnM64oh5qyPMoLsinLzyKswBeRgLHRul1dXV2dq6+vP6W/29UXITcz5DvmPRZz/H1XCxdOLObxl/YzuTyf1q5+mo720tzRS2VxDnOrS/i3373MM9sOD7mt2op8xhZmM74oh/HFuZTkZZIVymBmZRHlBVn0RmK8vK+Nd9VVayy+iIwYM1vtnKvzXS+I4T5SYjFHS1cfB9p6uH/VXgpywqzZc4SscIjC7DCHjvawv62Hg+099EdPftwqCrOZUJJLb3+U3kiM6WMLcMDi8yqoLMphfHEO1aV5FOaE6YvGyMkMndk3KSKBNtxwD2RZZqRkZBjlBdmUF2RzwcRiz/ViMUdbdz8dvRH2tnRxuLOPfa3dPLfjMPlZYdp7+ll/uJMjXf00tnbTF4nxpw0HT7qtKeX55GSGqC7NZe3eVuoml7JubxtXzRxLblaINbtb+cjiWjbtb+eeZ3dx7cUT+fjrpjEmP2tgG+09/bR29lNTlse6va38/qX9TB9bwHUXTwxsSWnt3lZ++uwuKotz+Jc3npeS9+Gc06cqOWeo5z5CeiNRuvuiZIYyaGzt5mhPhCc3HmRmZREH23vo7I3SF42y/VAnnX3xXxK7DneRGbJjPhUU5oQ52hM5YfsXVZcwtSKf7HCI5ev309rVz7yaEl5qbCMSczgHE0ty+fDlU/jApZPpjcR4/KX9HGjv4ebXTmHboQ7WN7ZxcU0p548vPJOHxtez25v5wE9WYUBvJMY3rruAm14z6aTrPrf9MHc/s5OS3ExuvfYCz09Cew538c+/WM3C2jL+9W3H347gWP3RWEq/WO+LxMgKB/OXrJx9VJYJqFjMcaSrjwPtPQO9868+uoFrL57A4vMq2HTgKO+9ayX52WGyQhl090c5f1wh08cV8PPnd7Owtozbb5rPj56OjyYCyAwZZnbMyKLB3l1XzeyJRQP7e3hNI87Bp98wnV+u3MO6hjbGFmbz9WsvoKIwm5zMED390WOC9GB7D79bt4+scAb/uHDSq+4hR2OOWx/bwBMbD9JwpJvainx++0+XctNdK9nZ3Ml3b7iIOVXF9Eai1O86wpyqEv66tYlvLt9EQXaYjt4IN8yv4hvXXUhWOIO27n6e2HCQ+ZNKWbG1iW/8fiO9iff/m39axCWTxwDxIN96sINZE4rYdugon7l/Lesb21l8XgV3va/OM5SP9vSzt6WbSCzGnKqSk64Ticb49K/W8oeXD7Dkognc9u65r+qYiJyMwj2NdfVFyMs6saLW0x8lO5yBmRGLOZ7ecogN+9pp6+4nGoPXzxhLZ1+ELz60nvHF2SxbPJVv/H4DTUd7iQ06DfKyQkSijr5ojMyQsWhqOSu2NJGbGaK7P8qcqmJebGgjK5TBJVNKuWBC8cAvEoClC6p557wqcjJDFOVk4nCEQxmU5mWy9WAH6xpaKc7N5B/mTCAjI/5L4Md/2c43l28a+KTyx88s5vzxhbyw5wif//U6djR3nvRYvHVOJf/nhov4wZNb+dHT2ykvyAKMls5j39OcqmK+ff0cPvqz1bR39/OuS6rZsK+dXYc72dvSTWVxDh09EUIh45oLK/nlyj0sXVDNssVTicZirNjSzLPbm3nPa2r469ZmfvLMroFt379sIdPGFlBWkE1bVz/FeZk45/jIvat5YuNBCrPDHO2N8NgnLxuy3CcyHAp38RSJxojE3EDPOxpztHT20dLZR380xrSxBexo6mTF1iauOK+CmZVFrN7dwi+e38N/bzjIuKJstjd1Ul6QDUBzRy8leZn88D3zuO/ve3jsxf3DasfksjxqyvIpzAnz1y1N1FYU8PDHX3vCer2RKA+90Mjq3UeYW1NCw5FuJhTn0NkX5ebXThnoXT+16RAPr22kLxKjtiKfeTWlPLSmke6+KLe9ey7FuZlsb+rgSw+tZ+XOw8Qc1IzJI+YcRzr7iDn47g0X8dY5lXz9sQ3c9bedx7Qjwxj4hfHuumrmTyrly4+up6c//olgYkkuja3dXDVjLAU5YR5Zu4/3L5rEsiumct0Pn6GnP8rn3nQ+77908qn8s4kACnc5Q5xz9EfdQMA659je1MnDaxqpLMkhK1G7jjlHc0cfE0pyWFQb/ySwfP1+DrT3crijF4CvLZnN1RdUnpF2R6IxXmpsY2ZlETmZoYGS1eAyzLq9rWxv6iCUYUwbW8DUigIeXbePktxM3jR7PABNR3v5yTM7eWTtPioKs1m7t3XgE86lU8u49+YFhEMZbG/q4GM/f4Eth46y8parGFuUc0x72rr6eX7nYeZUFVNZnHtGjoEEk8JdZBQNLpElbT14lDd+bwW3LpnNDXXVZIcz6I3EeHTdPr766Mt09kWpLc9n+WcuJzsc/1S1dm8rPf1RFtaWsb+tmwdfaGT62AKuPH+s5/cBG/a18/+e2squ5i6+c8McZk9QKSidKNxFzkJXfOcpxuRnsWFf+8AXvAALa8ewsLaM/3hiKxdVFdMXdWQYvLyvHYB3XDyRP208ODBy6rJp5Xz0iloKczIZk5fFhv3tRGOOcUXZfOAnqwhlGG3d/cypKubBf76UcCiDSDQ2MKS06Wgv7/rxcwDMqynlf18zg7JEmU3ObhrnLnIWmlVZxPL1BwCom1TKoqllVBbncuMl1WRkGOOKcrjnmV1sPniUzJAxtjCb1q5+Vu5sYf6kUm55y0ye2HiQ7/xxM3/b1nzSfRTlhPn9py5j1a4WPnv/OqZ9cTm1FfnsbeliVmURWw91kJMZoqWzj6KcMI+sbaR+dwtXzx5PQXaYqjG5TB9bSCTmKMvPIi8rRFdffHoOCQ6Fu8gZNG1swcDjez+04IRRT0sX1LB0Qc2Q2zh/fCFVpbl09EZoONJNe3c/V5xXQXZmiINtPbymdgxVpXlMLMmluy9G/a4W9rf1sKOpk6xwBmMLsynMyeRDl03h46+bxm9XN3D7X7YfM+JpKFnhDObXlDKnqpii3Eyqx+SRHc6gvbuftu5+FtaWMXtCkS4YG2Uqy4icQfc+t4svP/Iy82pKePBjJ44MGk2RaIzO3igb9rfT2NrN9qYOxhZms3z9AcIZxnM7DjOvppS1e1uJxobOjfKCbKpKc5lZWch54woHptyYUJJLVWkuzjEwDDZVnHPsbemmpiy9P2GoLCNyFspP9NTPxhJHOJRBcV4Gi6aWHfP6B187BXhl+obDHb3kZ4dZs6cVh2Nncyc7mjp525xKJpbksmJr/JqA/a09PP7SAe77+96BbZlBSW4mfZEYl0wZQ215Aa+bUcHc6hIKczJPue0PrWngs/evA+BLb53Jhy+vPeVtpQuFu8gZlKxUBPEukckyS/KL1+QvgUunlh+z3vXzq7h+fhUQ/4VwoL2HDfvaCYcyWLWzhb1HughlGM9sa+bpzU3c/Uz8eoLscAa5WSHm1ZRSN7mUa+dOHLje4mNXTqUkL34FdXNHL6t2tlCcm8nsCcUc7uzliw+tpyw/i8Odfdz+9Hbeu3DSOT8pn8oyImfQkc4+rr/jWX500/yzbk6fMy0Wczy0ppGMDHh4zT46eiOs3n3kmIvFksYWZrNscS3ZmSG+8sj6geXJdUvyMln+6cvZ1dzF0v98npteU8PXr70gLev+GgopIoHT3NFLUU4m+9u6eWTtPkrzMmnu6OMXK/fQnLjYDeBf3zaL2vJ87lyxgzV7j/DD98zjqpnjcM7xlu//lU0HjnLHe+edcFFcXyTGbX/awkuNrUwsyeXL/zCbguxgFTAU7iKSVpo7etnZ3MmM8YXH1OePn8Vzb0sXl3/7KbLCGbx59ngqi3OoKMimICfMf/1tJ9sOdTC5LI9dh7u48ZJq/v2dc0bj7ZwyfaEqImklea+F4x0/PXP1mDye/cLrue1PW3hq0yEOd/YNLAtnGN+/cS5L5k7k35dv4o6/bGdeTSnvuqSa9p5++iOxge8UItEYv/z7HioKslkwZUzgLvJSz11E0lp3X5RNB9oJJW7GM6EkPndPT3+UD/+0nr9ta6ayOIf9bT2Ywb03L2D+pFJ++uxuvvWHTUB8bP93rp/DkrkTR/OtACrLiIj46o/G+Nlzu/nr1iae2tx0wvKaMXl84nXTuG/VHrYcOMo9Ny8YuBfAaFG4i4i8Sg1Huvj2Hzaz+3Anb5g5jo8sriUnM8S2Q0e58c6VNHf0MmN8IRNKctnT0sWtSy5g0dQyeiNRbvntS2w91MH8SaX8r6tnkJs1MkMxFe4iIil0sL2HR9Y28udNh3hhT+vANNGTyvI41N5Ld390YN33Lqzh69deOCLt0BeqIiIpNK4oh2WLp7Js8VR6I1F2Nnfyl81NrNp1hIqCbJYuqOGd86v40D2r+Pnze8gJh7iwqpg3zx4/KhdUKdxFRF6l7HCIGeOLmDG+iI9eceyyry6ZTWt3/8CdvMYX5XDl+RVccV4FuVkh7n1uN7deewETS0b2piwqy4iIpJhzjk0HjvK7dfv4w/oDJ9wD+HTKNirLiIiMEjNjZmURMyuL+PybzueB1Q2YwbqGVsbkZ/PJ108b8TYo3EVERlBGhvGuS6oBuKGu+sztdzgrmdnVZrbZzLaZ2RdOsrzGzJ4yszVm9qKZXZP6poqIyHD5hruZhYAfAm8BZgFLzWzWcat9Cfi1c+5i4EbgR6luqIiIDN9weu4LgG3OuR3OuT7gV8CS49ZxQFHicTGwL3VNFBGRV2s44T4R2DvoeUPitcH+DXivmTUAjwOfPNmGzGyZmdWbWX1T04mX+oqISGoMq+Y+DEuBe5xzVcA1wM/M7IRtO+fudM7VOefqKioqUrRrERE53nDCvREY/BVvVeK1wT4E/BrAOfcckAOUIyIio2I44b4KmG5mU8wsi/gXpo8et84e4CoAM5tJPNxVdxERGSW+4e6ciwCfAP4IbCQ+KuZlM/uamb09sdrngI+Y2TrgPuADbrQufRURkdGbfsDMmoDdp/jXy4HmFDYnXei4nEjH5OR0XE4UlGMyyTnn+6XlqIX76TCz+uHMrXCu0XE5kY7Jyem4nCjdjkmqRsuIiMhZROEuIpKGghrud452A85SOi4n0jE5OR2XE6XVMQlkzV1ERIYW1J67iIgMIXDh7jf9cLoys+rEtMobzOxlM/t04vUxZvYnM9ua+LM08bqZ2Q8Sx+lFM5s3uu9g5JhZKDHd9GOJ51PMbGXivd+fuPgOM8tOPN+WWD55NNs9ksysxMweMLNNZrbRzBbpXAEz+2zi/896M7vPzHLS9XwJVLgPc/rhdBUBPuecmwUsBD6eeO9fAJ50zk0Hnkw8h/gxmp74WQbcfuabfMZ8mvgFdknfAr7nnJsGHCE+PQaJP48kXv9eYr109X3gD865GcBFxI/POX2umNlE4FNAnXPuAiBE/Ir79DxfnHOB+QEWAX8c9PwW4JbRbtcoHYtHgDcCm4HKxGuVwObE4x8DSwetP7BeOv0Qn+voSeD1wGOAEb8QJXz8OUP8KutFicfhxHo22u9hBI5JMbDz+Pemc2VghtsxiX//x4A3p+v5EqieO8ObfjjtJT4eXgysBMY55/YnFh0AxiUenyvH6j+A/wnEEs/LgFYXnzYDjn3fA8cksbwtsX66mUJ8bqefJMpVd5lZPuf4ueKcawS+S3wurP3E//1Xk6bnS9DC/ZxnZgXAb4HPOOfaBy9z8S7GOTP8yczeBhxyzq0e7bacZcLAPOB2F787WievlGCAc+9cAUh8x7CE+C+/CUA+cPWoNmoEBS3chzP9cNoys0ziwf4L59yDiZcPmlllYnklcCjx+rlwrF4LvN3MdhG/Q9jrideaS8wsefP3we974JgklhcDh89kg8+QBqDBObcy8fwB4mF/Lp8rAG8Adjrnmpxz/cCDxM+htDxfghbuw5l+OC2ZmQH/BWx0zt02aNGjwPsTj99PvBaffP19iZEQC4G2QR/J04Jz7hbnXJVzbjLxc+HPzrmbgKeA6xOrHX9Mksfq+sT6add7dc4dAPaa2fmJl64CNnAOnysJe4CFZpaX+P+UPC7peb6MdtH/FL4UuQbYAmwHvjja7TmD7/sy4h+jXwTWJn6uIV4DfBLYCjwBjEmsb8RHFm0HXiI+QmDU38cIHp8rgccSj2uBvwPbgN8A2YnXcxLPtyWW1452u0fweMwF6hPny8NAqc4VB/BVYBOwHvgZkJ2u54uuUBURSUNBK8uIiMgwKNxFRNKQwl1EJA0p3EVE0pDCXUQkDSncRUTSkMJdRCQNKdxFRNLQ/weX9W2BGWkyRAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.plot(struct.summary.cycle_index, struct.summary.energy_efficiency)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "conda_python3",
+   "language": "python",
+   "name": "conda_python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This PR adds a jupyter notebook with an example of how to install beep, download some example data from the fastcharge dataset, and run the full data pipeline.