### PR TITLE
Mat 1776 validation for new arbin projects

### DIFF
--- a/beep/tests/test_validate.py
+++ b/beep/tests/test_validate.py
@@ -279,13 +279,16 @@ class SimpleValidatorTest(unittest.TestCase):
 
             v = SimpleValidator()
             paths = ["FastCharge_000000_CH29.csv",
-                     "FastCharge_000025_CH8.csv"]
+                     "FastCharge_000025_CH8.csv",
+                     "PredictionDiagnostics_000151_test.052"]
             paths = [os.path.join(TEST_FILE_DIR, path) for path in paths]
             validate_record = v.validate_from_paths(paths, record_results=True,
                                                     skip_existing=False)
 
             self.assertEqual(validate_record['FastCharge_000000_CH29.csv']['method'], 'schema-arbin-lfp.yaml')
             self.assertEqual(validate_record['FastCharge_000025_CH8.csv']['method'], 'schema-arbin-lfp.yaml')
+            self.assertEqual(validate_record['PredictionDiagnostics_000151_test.052']['method'],
+                             'schema-maccor-2170.yaml')
 
     def test_validation_from_json(self):
         with ScratchDir('.'):

--- a/beep/tests/test_validate.py
+++ b/beep/tests/test_validate.py
@@ -271,6 +271,22 @@ class SimpleValidatorTest(unittest.TestCase):
         self.assertTrue(validity)
         self.assertEqual(reason, '')
 
+    def test_project_name(self):
+        with ScratchDir('.'):
+            os.environ['BEEP_PROCESSING_DIR'] = os.getcwd()
+            os.mkdir("data-share")
+            os.mkdir(os.path.join("data-share", "validation"))
+
+            v = SimpleValidator()
+            paths = ["FastCharge_000000_CH29.csv",
+                     "FastCharge_000025_CH8.csv"]
+            paths = [os.path.join(TEST_FILE_DIR, path) for path in paths]
+            validate_record = v.validate_from_paths(paths, record_results=True,
+                                                    skip_existing=False)
+
+            self.assertEqual(validate_record['FastCharge_000000_CH29.csv']['method'], 'schema-arbin-lfp.yaml')
+            self.assertEqual(validate_record['FastCharge_000025_CH8.csv']['method'], 'schema-arbin-lfp.yaml')
+
     def test_validation_from_json(self):
         with ScratchDir('.'):
             os.environ['BEEP_PROCESSING_DIR'] = os.getcwd()

--- a/beep/validation_schemas/schema-arbin-nmc-phev.yaml
+++ b/beep/validation_schemas/schema-arbin-nmc-phev.yaml
@@ -1,0 +1,34 @@
+charge_capacity:
+  schema:
+    max: 30.0
+    min: 0.0
+    type: float
+  type: list
+cycle_index:
+  schema:
+    min: 0
+    max_at_least: 1
+    type: integer
+  type: list
+discharge_capacity:
+  schema:
+    max: 30.0
+    min: 0.0
+    type: float
+  type: list
+temperature:
+  schema:
+    max: 80.0
+    min: 0.0
+    type: float
+  type: list
+test_time:
+  schema:
+    type: float
+  type: list
+voltage:
+  schema:
+    max: 4.3
+    min: 0.0
+    type: float
+  type: list

--- a/beep/validation_schemas/schema-projects.yaml
+++ b/beep/validation_schemas/schema-projects.yaml
@@ -1,0 +1,5 @@
+Iris: schema-arbin-nmc-phev.yaml
+PreDiag: schema-maccor-2170.yaml
+PredictionDiagnostics: schema-maccor-2170.yaml
+FastCharge: schema-arbin-lfp.yaml
+ClosedLoopOED: schema-arbin-lfp.yaml


### PR DESCRIPTION
This PR adds some structure around validation so that different projects can use different validation schemas.
- yaml file with project names and corresponding validation schemas
- new validation schema for Iris data
- test to make sure that the FastCharge project gets the right validation schema