### PR TITLE
Change logging options in the config for local to eliminate some errors

### DIFF
--- a/beep/config.py
+++ b/beep/config.py
@@ -9,7 +9,7 @@ config = {
     'local': {
         'logging': {
             'container': 'Testing',
-            'streams': ['file', 'stdout']
+            'streams': ['file']
         },
         'kinesis': {
             'stream': 'local/beep/eventstream'


### PR DESCRIPTION
This PR changes the logging configuration for 'local' to avoid test errors