### PR TITLE
Open full temperature range for validation

### DIFF
--- a/beep/validation_schemas/schema-arbin-nmc-phev.yaml
+++ b/beep/validation_schemas/schema-arbin-nmc-phev.yaml
@@ -18,7 +18,7 @@ discharge_capacity:
   type: list
 temperature:
   schema:
-    max: 80.0
+    max: 500.0
     min: 0.0
     type: float
   type: list


### PR DESCRIPTION
This PR opens the temperature range for xIris and Iris validation since some of the temperature channels seem to be malfunctioning and cannot be repaired due to limited lab access.