### PR TITLE
MAT-1932

### DIFF
--- a/beep/protocol/maccor_to_biologic_mb.py
+++ b/beep/protocol/maccor_to_biologic_mb.py
@@ -1,6 +1,11 @@
 # Copyright 2019 Toyota Research Institute. All rights reserved.
 """ Parsing and conversion of maccor procedure files to arbin schedule files"""
 
+import os
+from beep.protocol import PROTOCOL_SCHEMA_DIR
+from monty.serialization import loadfn
+from collections import OrderedDict
+
 
 class MaccorToBiologicMb:
     """
@@ -11,92 +16,11 @@ class MaccorToBiologicMb:
     """
 
     def __init__(self):
-        self.blank_seq = {
-            # sequence number
-            "Ns": "0",
-            # step to apply e.g. a rest
-            "type": "",
-            "Apply I/C": "",
-            "ctrl1_val": "",
-            "ctrl1_val_unit": "",
-            "ctrl1_val_vs": "",
-            "ctrl2_val": "",
-            "ctrl2_val_unit": "",
-            "ctrl2_val_vs": "",
-            "ctrl3_val": "",
-            "ctrl3_val_unit": "",
-            "ctrl3_val_vs": "",
-            # control triggers unsure what these do
-            # unknown
-            "N": "",
-            # whether seq is charge or discharge
-            "charge/discharge": "",
-            # unknown
-            "ctrl_seq": "0",
-            "ctrl_repeat": "0",
-            "ctrl_trigger": "Falling Edge",
-            "ctrl_TO_t": "0",
-            "ctrl_TO_t_unit": "d",
-            "ctrl_Nd": "6",
-            "ctrl_Na": "1",
-            "ctrl_corr": "1",
-            # Break conditions, when a limit is reached, perform limit action
-            # number of limits active
-            "lim_nb": "0",
-            # defaults for empty limit
-            "lim1_type": "Time",
-            "lim1_comp": "<",
-            "lim1_Q": "Q limit",
-            "lim1_value": "0.000",
-            "lim1_value_unit": "s",
-            # these fields determine behavior on breaking a limit threshold
-            # proper implementation requires global knowledge about the shape
-            # of the list and will be handled elsewhere
-            #
-            # confusingly, biologic limits are equivalent to maccor endtypes
-            # biologic limits have to do with safety ranges on I and E.
-            "lim1_action": "Next sequence",
-            "lim1_seq": "0",
-            "lim2_type": "Time",
-            "lim2_comp": "<",
-            "lim2_Q": "Q limit",
-            "lim2_value": "0.000",
-            "lim2_value_unit": "s",
-            "lim2_action": "Next sequence",
-            "lim2_seq": "0",
-            "lim3_type": "Time",
-            "lim3_comp": "<",
-            "lim3_Q": "Q limit",
-            "lim3_value": "0.000",
-            "lim3_value_unit": "s",
-            "lim3_action": "Next sequence",
-            "lim3_seq": "0",
-            # conditions on which to record data
-            # number of record controls active
-            "rec_nb": "0",
-            # default empty record control
-            "rec1_type": "Time",
-            "rec1_value": "10.000",
-            "rec1_value_unit": "s",
-            "rec2_type": "Time",
-            "rec2_value": "10.000",
-            "rec2_value_unit": "s",
-            "rec3_type": "Time",
-            "rec3_value": "10.000",
-            "rec3_value_unit": "s",
-            # global settings
-            "E range min (V)": "0.000",
-            "E range max (V)": "10.000",
-            # not sure how to determine how to set this
-            "I Range": "1 mA",
-            # custom step limits on I range I think
-            "I Range min (V)": "Unset",
-            "I Range max (V)": "Unset",
-            "I Range init": "Unset",
-            # not sure what this is or how to think about it
-            "auto rest": "1",
-            "Bandwidth": "4",
-        }
+        BIOLOGIC_SCHEMA = loadfn(
+            os.path.join(PROTOCOL_SCHEMA_DIR, "biologic_mb_schema.yaml")
+        )
+        schema = OrderedDict(BIOLOGIC_SCHEMA)
+        self.blank_seq = schema["blank_seq"]
 
     def __proc_step_to_seq(self, test_step, seq_num):
         """

--- a/beep/protocol/maccor_to_biologic_mb.py
+++ b/beep/protocol/maccor_to_biologic_mb.py
@@ -22,7 +22,7 @@ class MaccorToBiologicMb:
         schema = OrderedDict(BIOLOGIC_SCHEMA)
         self.blank_seq = schema["blank_seq"]
 
-    def __proc_step_to_seq(self, test_step, seq_num):
+    def _proc_step_to_seq(self, test_step, seq_num):
         """
         converts steps that are not related to control flow to sequence dicts
         (control flow steps are DO, LOOP, ADV CYCLE)

--- a/beep/protocol/maccor_to_biologic_mb.py
+++ b/beep/protocol/maccor_to_biologic_mb.py
@@ -1,0 +1,298 @@
+# Copyright 2019 Toyota Research Institute. All rights reserved.
+""" Parsing and conversion of maccor procedure files to arbin schedule files"""
+
+
+class MaccorToBiologicMb:
+    """
+    Collection of methods to convert maccor protocol files to biologic modulo bat protocol files
+    Differences in underlying hardware and software makes this impossible in some cases
+    or forces workarounds that may fail. Certain work-arounds may be attempted and are
+    documented under the conversion function.
+    """
+
+    def __init__(self):
+        self.blank_seq = {
+            # sequence number
+            "Ns": "0",
+            # step to apply e.g. a rest
+            "type": "",
+            "Apply I/C": "",
+            "ctrl1_val": "",
+            "ctrl1_val_unit": "",
+            "ctrl1_val_vs": "",
+            "ctrl2_val": "",
+            "ctrl2_val_unit": "",
+            "ctrl2_val_vs": "",
+            "ctrl3_val": "",
+            "ctrl3_val_unit": "",
+            "ctrl3_val_vs": "",
+            # control triggers unsure what these do
+            # unknown
+            "N": "",
+            # whether seq is charge or discharge
+            "charge/discharge": "",
+            # unknown
+            "ctrl_seq": "0",
+            "ctrl_repeat": "0",
+            "ctrl_trigger": "Falling Edge",
+            "ctrl_TO_t": "0",
+            "ctrl_TO_t_unit": "d",
+            "ctrl_Nd": "6",
+            "ctrl_Na": "1",
+            "ctrl_corr": "1",
+            # Break conditions, when a limit is reached, perform limit action
+            # number of limits active
+            "lim_nb": "0",
+            # defaults for empty limit
+            "lim1_type": "Time",
+            "lim1_comp": "<",
+            "lim1_Q": "Q limit",
+            "lim1_value": "0.000",
+            "lim1_value_unit": "s",
+            # these fields determine behavior on breaking a limit threshold
+            # proper implementation requires global knowledge about the shape
+            # of the list and will be handled elsewhere
+            #
+            # confusingly, biologic limits are equivalent to maccor endtypes
+            # biologic limits have to do with safety ranges on I and E.
+            "lim1_action": "Next sequence",
+            "lim1_seq": "0",
+            "lim2_type": "Time",
+            "lim2_comp": "<",
+            "lim2_Q": "Q limit",
+            "lim2_value": "0.000",
+            "lim2_value_unit": "s",
+            "lim2_action": "Next sequence",
+            "lim2_seq": "0",
+            "lim3_type": "Time",
+            "lim3_comp": "<",
+            "lim3_Q": "Q limit",
+            "lim3_value": "0.000",
+            "lim3_value_unit": "s",
+            "lim3_action": "Next sequence",
+            "lim3_seq": "0",
+            # conditions on which to record data
+            # number of record controls active
+            "rec_nb": "0",
+            # default empty record control
+            "rec1_type": "Time",
+            "rec1_value": "10.000",
+            "rec1_value_unit": "s",
+            "rec2_type": "Time",
+            "rec2_value": "10.000",
+            "rec2_value_unit": "s",
+            "rec3_type": "Time",
+            "rec3_value": "10.000",
+            "rec3_value_unit": "s",
+            # global settings
+            "E range min (V)": "0.000",
+            "E range max (V)": "10.000",
+            # not sure how to determine how to set this
+            "I Range": "1 mA",
+            # custom step limits on I range I think
+            "I Range min (V)": "Unset",
+            "I Range max (V)": "Unset",
+            "I Range init": "Unset",
+            # not sure what this is or how to think about it
+            "auto rest": "1",
+            "Bandwidth": "4",
+        }
+
+    def __proc_step_to_seq(self, test_step, seq_num):
+        """
+        converts steps that are not related to control flow to sequence dicts
+        (control flow steps are DO, LOOP, ADV CYCLE)
+        """
+        new_seq = {}
+        new_seq.update(self.blank_seq)
+        new_seq["Ns"] = seq_num
+        new_seq["lim1_seq"] = seq_num
+        new_seq["lim2_seq"] = seq_num
+        new_seq["lim3_seq"] = seq_num
+
+        # while biologic does not have >= or <= these are functionally
+        # equivalent to > and < for bounds checks on floating points
+        # most of the time
+        operator_map = {
+            ">=": ">",
+            "<=": "<",
+        }
+
+        step_type = test_step["StepType"]
+        assert type(step_type) == str
+
+        step_mode = test_step["StepMode"]
+        step_value = test_step["StepValue"]
+
+        if step_type == "Rest":
+            new_seq["ctrl_type"] = "Rest"
+            new_seq["Apply I/C"] = "I"
+
+            # magic number
+            new_seq["N"] = "1.00"
+
+            # should this depend on the previous step?
+            # it seems like the value only matters if we were advancing cycle number
+            # on charge discharge alternance. By default EC-lab seems to set this
+            # to the previous steps charge/discharge
+            new_seq["charge/discharge"] = "Charge"
+
+        # Maccor intentionally misspells Discharge
+        elif step_type not in ["Charge", "Dischrge"]:
+            raise Exception("Unsupported Control StepType", step_type)
+        elif step_mode == "Current":
+            assert type(step_value) == str
+            # does this need to be formatted? e.g. 1.0 from Maccor vs 1.000 for biologic
+            new_seq["ctrl1_val"] = step_value
+
+            new_seq["ctrl_type"] = "CC"
+            new_seq["Apply I/C"] = "C / N"
+            new_seq["ctrl1_val_unit"] = "A"
+            new_seq["ctrl1_val_vs"] = "<None>"
+
+            # magic number, unsure what this does
+            new_seq["N"] = "15.00"
+            new_seq["charge/discharge"] = (
+                "Charge" if step_type == "Charge" else "Discharge"
+            )
+        elif step_mode == "Voltage":
+            # does this need to be formatted? e.g. 1.0 from Maccor vs 1.000 for biologic
+            assert type(step_value) == str
+            new_seq["ctrl1_val"] = step_value
+            new_seq["ctrl_type"] = "CV"
+            new_seq["Apply I/C"] = "C / N"
+            new_seq["ctrl1_val_unit"] = "V"
+            new_seq["ctrl1_val_vs"] = "Ref"
+
+            # magic number, unsure what this does
+            new_seq["N"] = "15.00"
+            new_seq["charge/discharge"] = (
+                "Charge" if step_type == "Charge" else "Discharge"
+            )
+        else:
+            raise Exception("Unsupported Charge/Discharge StepMode", step_mode)
+
+        end_entries = test_step["Ends"]["EndEntry"]
+        end_entries_list = (
+            end_entries
+            if isinstance(end_entries, list)
+            else []
+            if end_entries is None
+            else [end_entries]
+        )
+
+        # maccor end entries are conceptually equivalent to biologic limits
+        num_lims = len(end_entries_list)
+        assert num_lims <= 3
+        new_seq["lim_nb"] = "{0}".format(num_lims)
+
+        for idx, end_entry in enumerate(end_entries_list):
+            lim_num = idx + 1
+
+            end_type = end_entry["EndType"]
+            assert type(end_type) == str
+
+            end_oper = end_entry["Oper"]
+            assert type(end_oper) == str
+
+            end_value = end_entry["Value"]
+            assert type(end_value) == str
+
+            if end_type == "StepTime":
+                if end_oper != "=":
+                    raise Exception(
+                        "Unsupported StepTime operator in EndEntry", end_oper
+                    )
+
+                # Maccor time strings always contain two colons
+                # at least one section must be a parseable float
+                # "00:32:50" - 32 minutes and 50 seconds
+                # "::.5" - 5 ms
+                # "3600::" - 3600 hours
+                #
+                # are all possible values
+                # the smallest possible value is
+                # "::.01" - 10ms
+                # longest value unknown
+                hour_str, min_str, sec_str = end_value.split(":")
+                hours = 0 if hour_str == "" else float(hour_str)
+                mins = 0 if min_str == "" else float(min_str)
+                secs = 0 if sec_str == "" else float(sec_str)
+
+                ms = int(hours * 60 * 60 * 1000 + mins * 60 * 1000 + secs * 1000)
+
+                new_seq["lim{0}_type".format(lim_num)] = "Time"
+                new_seq["lim{0}_value_unit".format(lim_num)] = "ms"
+                new_seq["lim{0}_value".format(lim_num)] = "{0}".format(ms)
+                # even though maccor claims it checks for time equal to some threshold
+                # it's actually looking for time greater than or equal to that threshold
+                # biologic has no >=  so we use >
+                new_seq["lim{0}_comp".format(lim_num)] = ">"
+            elif end_type == "Voltage":
+                if operator_map[end_oper] is None:
+                    raise Exception(
+                        "Unsupported Voltage operator in EndEntry", end_oper
+                    )
+
+                new_seq["lim{0}_comp".format(lim_num)] = operator_map[end_oper]
+                new_seq["lim{0}_type".format(lim_num)] = "Voltage"
+                new_seq["lim{0}_value".format(lim_num)] = end_value
+                new_seq["lim{0}_value_unit".format(lim_num)] = "V"
+            elif end_type == "Current":
+                if operator_map[end_oper] is None:
+                    raise Exception(
+                        "Unsupported Voltage operator in EndEntry", end_oper
+                    )
+
+                new_seq["lim{0}_comp".format(lim_num)] = operator_map[end_oper]
+                new_seq["lim{0}_type".format(lim_num)] = "Current"
+                new_seq["lim{0}_value".format(lim_num)] = end_value
+                new_seq["lim{0}_value_unit".format(lim_num)] = "A"
+            else:
+                raise Exception("Unsupported EndType", end_type)
+
+        report_entries = test_step["Reports"]["ReportEntry"]
+        report_entries_list = (
+            report_entries
+            if isinstance(report_entries, list)
+            else []
+            if report_entries is None
+            else [report_entries]
+        )
+
+        num_reports = len(report_entries_list)
+        assert num_reports <= 3
+        new_seq["rec_nb"] = "{0}".format(num_reports)
+
+        for idx, report in enumerate(report_entries_list):
+            rec_num = idx + 1
+
+            report_type = report["ReportType"]
+            assert type(report_type) == str
+
+            report_value = report["Value"]
+            assert type(report_value) == str
+
+            if report_type == "StepTime":
+                hour_str, min_str, sec_str = report_value.split(":")
+                hours = 0 if hour_str == "" else float(hour_str)
+                mins = 0 if min_str == "" else float(min_str)
+                secs = 0 if sec_str == "" else float(sec_str)
+
+                ms = int(hours * 60 * 60 * 1000 + mins * 60 * 1000 + secs * 1000)
+
+                new_seq["rec{0}_type".format(rec_num)] = "Time"
+                new_seq["rec{0}_value".format(rec_num)] = "{}".format(ms)
+                new_seq["rec{0}_value_unit".format(rec_num)] = "ms"
+            elif report_type == "Voltage":
+                new_seq["rec{0}_type".format(rec_num)] = "Voltage"
+                new_seq["rec{0}_value".format(rec_num)] = report_value
+                new_seq["rec{0}_value_unit".format(rec_num)] = "V"
+            elif report_type == "Current":
+                new_seq["rec{0}_type".format(rec_num)] = "Current"
+                new_seq["rec{0}_value".format(rec_num)] = report_value
+                new_seq["rec{0}_value_unit".format(rec_num)] = "A"
+            else:
+                raise Exception("Unsupported ReportType", report_type)
+
+        return new_seq

--- a/beep/protocol/protocol_schemas/biologic_mb_schema.yaml
+++ b/beep/protocol/protocol_schemas/biologic_mb_schema.yaml
@@ -1,0 +1,85 @@
+blank_seq:
+  # sequence number
+  Ns: "0"
+  # step to apply e.g. a rest
+  type: ""
+  Apply I/C: ""
+  ctrl1_val: ""
+  ctrl1_val_unit: ""
+  ctrl1_val_vs: ""
+  ctrl2_val: ""
+  ctrl2_val_unit: ""
+  ctrl2_val_vs: ""
+  ctrl3_val: ""
+  ctrl3_val_unit: ""
+  ctrl3_val_vs: ""
+  # control triggers unsure what these do
+  # unknown
+  N: ""
+  # whether seq is charge or discharge
+  charge/discharge: ""
+  # unknown
+  ctrl_seq: "0"
+  ctrl_repeat: "0"
+  ctrl_trigger: "Falling Edge"
+  ctrl_TO_t: "0"
+  ctrl_TO_t_unit: "d"
+  ctrl_Nd: "6"
+  ctrl_Na: "1"
+  ctrl_corr: "1"
+  # Break conditions when a limit is reached perform limit action
+  # number of limits active
+  lim_nb: "0"
+  # defaults for empty limit
+  lim1_type: "Time"
+  lim1_comp: "<"
+  lim1_Q: "Q limit"
+  lim1_value: "0.000"
+  lim1_value_unit: "s"
+  # these fields determine behavior on breaking a limit threshold
+  # proper implementation requires global knowledge about the shape
+  # of the list and will be handled elsewhere
+  #
+  # confusingly biologic limits are equivalent to maccor endtypes
+  # biologic limits have to do with safety ranges on I and E.
+  lim1_action: "Next sequence"
+  lim1_seq: "0"
+  lim2_type: "Time"
+  lim2_comp: "<"
+  lim2_Q: "Q limit"
+  lim2_value: "0.000"
+  lim2_value_unit: "s"
+  lim2_action: "Next sequence"
+  lim2_seq: "0"
+  lim3_type: "Time"
+  lim3_comp: "<"
+  lim3_Q: "Q limit"
+  lim3_value: "0.000"
+  lim3_value_unit: "s"
+  lim3_action: "Next sequence"
+  lim3_seq: "0"
+  # conditions on which to record data
+  # number of record controls active
+  rec_nb: "0"
+  # default empty record control
+  rec1_type: "Time"
+  rec1_value: "10.000"
+  rec1_value_unit: "s"
+  rec2_type: "Time"
+  rec2_value: "10.000"
+  rec2_value_unit: "s"
+  rec3_type: "Time"
+  rec3_value: "10.000"
+  rec3_value_unit: "s"
+  # global settings
+  E range min (V): "0.000"
+  E range max (V): "10.000"
+  # not sure how to determine how to set this
+  I Range: "1 mA"
+  # custom step limits on I range I think
+  I Range min (V): "Unset"
+  I Range max (V): "Unset"
+  I Range init: "Unset"
+  # not sure what this is or how to think about it
+  auto rest: "1"
+  Bandwidth: "4"

--- a/beep/tests/test_maccor_to_biologic_mb.py
+++ b/beep/tests/test_maccor_to_biologic_mb.py
@@ -1,0 +1,180 @@
+# Copyright 2019 Toyota Research Institute. All rights reserved.
+"""Unit tests for maccor protcol files to biologic modulo bat protcol files"""
+
+import os
+import unittest
+import xmltodict
+from beep.protocol.maccor_to_biologic_mb import MaccorToBiologicMb
+
+
+class ConversionTest(unittest.TestCase):
+    def proc_step_to_seq_test(self, test_step_xml, diff_dict):
+        """
+        test utility for testing proc_step_to_seq
+         """
+        proc = xmltodict.parse(test_step_xml)
+        test_step = proc["MaccorTestProcedure"]["ProcSteps"]["TestStep"]
+        converter = MaccorToBiologicMb()
+
+        expected = {}
+        expected.update(converter.blank_seq)
+        expected.update(diff_dict)
+
+        result = converter._MaccorToBiologicMb__proc_step_to_seq(test_step, "0",)
+        for key, value in expected.items():
+            self.assertEqual(
+                value,
+                result[key],
+                msg="Expected {0}: {1} got {0}: {2}".format(key, value, result[key]),
+            )
+
+    def test_rest_step_conversion(self):
+        xml = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            "<MaccorTestProcedure>"
+            "  <ProcSteps>"
+            "    <TestStep>"
+            "      <StepType>  Rest  </StepType>"
+            "      <StepMode>        </StepMode>"
+            "      <StepValue></StepValue>"
+            "      <Limits/>"
+            "      <Ends>"
+            "        <EndEntry>"
+            "          <EndType>Voltage </EndType>"
+            "          <SpecialType> </SpecialType>"
+            "          <Oper>&gt;= </Oper>"
+            "          <Step>070</Step>"
+            "          <Value>4.4</Value>"
+            "        </EndEntry>"
+            "        <EndEntry>"
+            "          <EndType>Voltage </EndType>"
+            "          <SpecialType> </SpecialType>"
+            "          <Oper>&lt;= </Oper>"
+            "          <Step>070</Step>"
+            "          <Value>2.5</Value>"
+            "        </EndEntry>"
+            "      </Ends>"
+            "      <Reports>"
+            "        <ReportEntry>"
+            "          <ReportType>Voltage</ReportType>"
+            "          <Value>2.2</Value>"
+            "        </ReportEntry>"
+            "      </Reports>"
+            "      <Range>A</Range>"
+            "      <Option1>N</Option1>"
+            "      <Option2>N</Option2>"
+            "      <Option3>N</Option3>"
+            "      <StepNote></StepNote>"
+            "    </TestStep>"
+            "  </ProcSteps>"
+            "</MaccorTestProcedure>"
+        )
+        diff_dict = {
+            "ctrl_type": "Rest",
+            "Apply I/C": "I",
+            "N": "1.00",
+            "charge/discharge": "Charge",
+            "lim_nb": "2",
+            "lim1_type": "Voltage",
+            "lim1_comp": ">",
+            "lim1_value": "4.4",
+            "lim1_value_unit": "V",
+            "lim2_type": "Voltage",
+            "lim2_comp": "<",
+            "lim2_value": "2.5",
+            "lim2_value_unit": "V",
+            "rec_nb": "1",
+            "rec1_type": "Voltage",
+            "rec1_value": "2.2",
+            "rec1_value_unit": "V",
+        }
+
+        self.proc_step_to_seq_test(xml, diff_dict)
+        pass
+
+    def test_discharge_current_step_conversion(self):
+        xml = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            "<MaccorTestProcedure>"
+            "  <ProcSteps>"
+            "    <TestStep>"
+            #      mispelling taken directly from sample file
+            "      <StepType>Dischrge</StepType>"
+            "      <StepMode>Current </StepMode>"
+            "      <StepValue>1.0</StepValue>"
+            "      <Limits/>"
+            "      <Ends>"
+            "        <EndEntry>"
+            "          <EndType>StepTime</EndType>"
+            "          <SpecialType> </SpecialType>"
+            "          <Oper> = </Oper>"
+            "          <Step>013</Step>"
+            "          <Value>00:00:30</Value>"
+            "        </EndEntry>"
+            "        <EndEntry>"
+            "          <EndType>Voltage </EndType>"
+            "          <SpecialType> </SpecialType>"
+            "          <Oper>&lt;= </Oper>"
+            "          <Step>017</Step>"
+            "          <Value>2.7</Value>"
+            "        </EndEntry>"
+            "        <EndEntry>"
+            "          <EndType>Voltage </EndType>"
+            "          <SpecialType> </SpecialType>"
+            "          <Oper>&gt;= </Oper>"
+            "          <Step>070</Step>"
+            "          <Value>4.4</Value>"
+            "        </EndEntry>"
+            "      </Ends>"
+            "      <Reports>"
+            "        <ReportEntry>"
+            "          <ReportType>Voltage </ReportType>"
+            "          <Value>0.001</Value>"
+            "        </ReportEntry>"
+            "        <ReportEntry>"
+            "          <ReportType>StepTime</ReportType>"
+            #          10ms
+            "          <Value>::.01</Value>"
+            "        </ReportEntry>"
+            "      </Reports>"
+            "      <Range>A</Range>"
+            "      <Option1>N</Option1>"
+            "      <Option2>N</Option2>"
+            "      <Option3>N</Option3>"
+            "      <StepNote></StepNote>"
+            "    </TestStep>"
+            "  </ProcSteps>"
+            "</MaccorTestProcedure>"
+        )
+        diff_dict = {
+            "ctrl_type": "CC",
+            "Apply I/C": "C / N",
+            "ctrl1_val": "1.0",
+            "ctrl1_val_unit": "A",
+            "ctrl1_val_vs": "<None>",
+            "N": "15.00",
+            "charge/discharge": "Discharge",
+            "lim_nb": "3",
+            "lim1_type": "Time",
+            "lim1_comp": ">",
+            "lim1_value": "30000",
+            "lim1_value_unit": "ms",
+            "lim2_type": "Voltage",
+            "lim2_comp": "<",
+            "lim2_value": "2.7",
+            "lim2_value_unit": "V",
+            "lim3_type": "Voltage",
+            "lim3_comp": ">",
+            "lim3_value": "4.4",
+            "lim3_value_unit": "V",
+            "rec_nb": "2",
+            "rec1_type": "Voltage",
+            "rec1_value": "0.001",
+            "rec1_value_unit": "V",
+            "rec2_type": "Time",
+            "rec2_value": "10",
+            "rec2_value_unit": "ms",
+        }
+
+        self.proc_step_to_seq_test(xml, diff_dict)
+        pass

--- a/beep/tests/test_maccor_to_biologic_mb.py
+++ b/beep/tests/test_maccor_to_biologic_mb.py
@@ -20,7 +20,7 @@ class ConversionTest(unittest.TestCase):
         expected.update(converter.blank_seq)
         expected.update(diff_dict)
 
-        result = converter._MaccorToBiologicMb__proc_step_to_seq(test_step, "0",)
+        result = converter._proc_step_to_seq(test_step, "0",)
         for key, value in expected.items():
             self.assertEqual(
                 value,


### PR DESCRIPTION
To convert Maccor protocol files to Biologic Protocol files we will need to be able to control what I'm calling "procedural steps" to sequences as opposed to the other type of Maccor step - "control steps".

Control steps are any of the following:
- Advancing Cycle Number
- Looping
- Do statements (beginning a cycle)

All other steps are procedural steps.

Procedural steps have a "control" portion to them, in that when a `<ReportEntry>` limit is reached they will go to some other arbitrary step. Since the mapping of steps to sequences is not 1-1 we'll need a more global context about the correspondence between step number from the input and sequence number in the output.

This behavior will be handled separately in a PR that's pending for the actual conversion.