### PR TITLE
MAT-1962 featurization failure

### DIFF
--- a/beep/features/featurizer_helpers.py
+++ b/beep/features/featurizer_helpers.py
@@ -836,9 +836,9 @@ def get_relaxation_features(processed_cycler_run, hppc_list=[0, 1], max_n_soc=10
 
         all_time_array = np.nan * np.ones((max_n_soc, 3))
 
-        # If there is an error and there are more than 10 SOC windows truncate it
-        # to the last 9 elements.  Otherwise take all the available ones from the second
-        # element onwards (first relaxation curve comes out of a CV and must be ignored)
+        # If there are more than 10 SOC windows truncate it to the last 9 elements.  Otherwise take
+        # all the available ones from the second element onwards (first relaxation curve comes out
+        # of a CV and must be ignored)
         if len(step_count_list) > max_n_soc:
             step_count_list = step_count_list[-(max_n_soc - 1):]
         else:

--- a/beep/features/featurizer_helpers.py
+++ b/beep/features/featurizer_helpers.py
@@ -834,7 +834,7 @@ def get_relaxation_features(processed_cycler_run, hppc_list=[0, 1], max_n_soc=10
         step_count_list = list(set(step_count_list))
         step_count_list.sort()
 
-        all_time_array = np.nan * np.ones((max_n_soc, 3))
+        all_time_array = np.nan * np.ones((max_n_soc-1, 3))
 
         # If there are more than 10 SOC windows truncate it to the last 9 elements.  Otherwise take
         # all the available ones from the second element onwards (first relaxation curve comes out


### PR DESCRIPTION
Updated one of the helper functions for class HPPCRelaxationFeatures to handle errors caused due to occasional size mismatches between expected vs actual number of calculated SOC windows
In the fig attached, there should be only one relaxation curve around t=120000 and max 10 SOC windows. 

![image](https://user-images.githubusercontent.com/47153264/91352650-fa651900-e79e-11ea-8916-5e260f04effb.png)
