### PR TITLE
Add newline to end of init and setup

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -41,6 +41,7 @@ def set_ver(ctx):
                 lines.append(l.rstrip())
     with open("beep/__init__.py", "wt") as f:
         f.write("\n".join(lines))
+        f.write("\n")
 
     lines = []
     with open("setup.py", "rt") as f:
@@ -49,6 +50,7 @@ def set_ver(ctx):
                                 l.rstrip()))
     with open("setup.py", "wt") as f:
         f.write("\n".join(lines))
+        f.write("\n")
 
 
 @task


### PR DESCRIPTION
This PR adds a newline to the end of the file when the release process is invoked so that the linting check passes.