### PR TITLE
MAT-1973 Biologic mb to Maccor converter (part 2)

### DIFF
--- a/beep/protocol/biologic_mb_to_maccor.py
+++ b/beep/protocol/biologic_mb_to_maccor.py
@@ -1,9 +1,13 @@
 # Copyright 2020 Toyota Research Institute. All rights reserved.
 """ Parsing and conversion of biologic Modulo Bat files to Maccor Procedure Files"""
 import os
+import re
 from copy import deepcopy
 from collections import OrderedDict
+import xmltodict
 from monty.serialization import loadfn
+from beep.protocol.biologic import Settings
+from beep.protocol.maccor import Procedure
 from beep.protocol import PROCEDURE_TEMPLATE_DIR
 
 
@@ -17,6 +21,105 @@ _blank_maccor_body = OrderedDict(MACCOR_TEMPLATE["blank_maccor_body"])
 
 
 class BiologicMbToMaccorProcedure:
+    @classmethod
+    def convert(
+        cls,
+        mps_filepath,
+        out_filepath,
+        mps_file_encoding="ISO-8859-1",
+        maccor_header=_default_maccor_header,
+    ):
+        """
+        Biologic Modulo Bat file ingestion from
+        *.mps file with a single Modulo Bat technique
+
+        Args:
+            mps_filepath(str): *.mps filepath
+            out_filepath(str): target destination for Maccor Procedure
+            (optional) mps_file_encoding(str): text encoding of *.mps
+            (optional) maccor_header(OrderedDict): This defines the shape of the <header> in
+                the output file
+            
+        Returns: None on success, otherwise throws an error
+        """
+        if not os.path.isfile(mps_filepath):
+            raise Exception(
+                "Could not load {}, filepath does not exist".format(mps_filepath)
+            )
+
+        with open(mps_filepath, "rb") as mps_file:
+            raw_text = mps_file.read()
+            text = raw_text.decode(mps_file_encoding)
+
+        protocol_xml = cls.biologic_mb_text_to_maccor_xml(text, maccor_header)
+
+        with open(out_filepath, "w+") as out_file:
+            out_file.write(protocol_xml)
+        
+        return None
+
+
+    """
+    Biologic Modulo Bat text ingestion from
+    *.mps file with a single Modulo Bat technique
+
+    Args:
+        text (str): the text from a *.mps file
+        
+    Returns:
+        (xml): string containing the XML for a Maccor Procedure
+    """
+    @classmethod
+    def biologic_mb_text_to_maccor_xml(
+        cls, mps_text, maccor_header=_default_maccor_header
+    ):
+        schedule_dict = Settings.mps_text_to_schedule_dict(mps_text)
+
+        seqs = cls._get_seqs(schedule_dict)
+        steps = cls._create_steps(seqs)
+
+        body = deepcopy(_blank_maccor_body)
+        body["MaccorTestProcedure"]["header"] = maccor_header
+        body["MaccorTestProcedure"]["ProcSteps"] = OrderedDict({"TestStep": steps})
+
+        newLine = "\r\n"
+        xml_with_dirty_empty_elemnts = xmltodict.unparse(
+            body, encoding="utf-8", pretty=True, indent="  ", newl=newLine
+        )
+        xml = Procedure.fixup_empty_elements(xml_with_dirty_empty_elemnts)
+        # xmltodict's unparse does not accept custom processing instructions,
+        # we must add Maccor's ourselves
+        xml_with_maccor_processing_instruction = re.sub(
+            r"^[^\r^\n]*",
+            '<?xml version="1.0" encoding="UTF-8"?>\r\n<?maccor-application progid="Maccor Procedure File"?>',
+            xml,
+        )
+
+        # newline at EOF
+        return xml_with_maccor_processing_instruction + newLine
+
+
+    @classmethod
+    def _get_seqs(cls, shcedule_dict):
+        techniques = shcedule_dict["Technique"]
+        assert len(techniques.items()) == 1
+
+        modulo_bat = techniques["1"]
+        assert modulo_bat["Type"] == "Modulo Bat"
+
+        # Steps are equivelant to seqs
+        numbered_seqs = list(modulo_bat["Step"].items())
+   
+        # biologic parser may create empty seq(s) at the end
+        # we intentionally _don't_ filter because if there is
+        # a blank seq at in the middle
+        seqs = list(map(lambda pair: pair[1], numbered_seqs))
+
+        if len(seqs) > 0 and seqs[-1]["Ns"] == "":
+            seqs = seqs[:-1]
+
+        return seqs
+
     @classmethod
     def _stringify_step_num(cls, step_num):
         return "{0:0=3d}".format(step_num)
@@ -398,3 +501,247 @@ class BiologicMbToMaccorProcedure:
         )
 
         return step
+
+    @classmethod
+    def _create_steps(cls, seqs):
+        # DANGER
+        #
+        # This code has a lot of complexity and subtlties I couldn't figure out
+        # how to remove
+        #
+        # all of the various passes over the list of sequences are _very_ tightly coupled
+
+        # start build building up a mapping of where loops start and stop
+        # since loops are defined at their end instead of beginning, we will
+        # iterate from the right.
+        #
+        # during this process we want to assert loop overlap invariants
+
+        containing_loop_range_by_seq_num = {}
+        seq_num_is_non_empty_loop_start = set()
+        curr_loop_start = float("inf")
+        curr_loop_end = float("inf")
+
+        seqs_in_reverse_order = seqs.copy()
+        list.reverse(seqs_in_reverse_order)
+        for seq in seqs_in_reverse_order:
+            is_loop_seq = seq["ctrl_type"] == "Loop"
+            seq_num = int(seq["Ns"])
+            loop_to = int(seq["ctrl_seq"])
+            loop_is_empty = seq["ctrl_repeat"] == "0"
+
+            # handle loops
+            if is_loop_seq and not loop_is_empty and loop_to >= curr_loop_start:
+                # Biologic does not have nested loops, maccor does not allow
+                # you to loop back into already completed loops
+                # to handle this we're disallowing any overlapping loops
+                # empty loops that do nothing are excepted
+                raise Exception(
+                    "Illegal loop at Seq {}. Loops are not allowed to".format(seq_num)
+                    + "overlap and Seq {} overlaps with the loop from".format(seq_num)
+                    + " seqs {}-{}".format(curr_loop_start, curr_loop_end)
+                )
+            elif is_loop_seq and not loop_is_empty:
+                curr_loop_end = seq_num
+                curr_loop_start = loop_to
+                seq_num_is_non_empty_loop_start.update([loop_to])
+
+            if seq_num >= curr_loop_start:
+                containing_loop_range_by_seq_num.update(
+                    {seq_num: (curr_loop_start, curr_loop_end)}
+                )
+
+        for loop_start in seq_num_is_non_empty_loop_start:
+            assert loop_start in containing_loop_range_by_seq_num
+            assert loop_start == containing_loop_range_by_seq_num[loop_start][0]
+
+        # once we know where loops start and end, we know where to include the
+        # "Do" steps, as well as where to create "Adv cycle" steps constructed from
+        # a blank loop followed immediately by a loop that goes back to the
+        # blank loop exactly once, causing the maccor system to advance the cycle
+        #
+        # now we'll build up a mapping of seq numbers to step numbers to build out our
+        # steps later
+        loop_active = False
+        curr_step = 1
+        curr_loop_start = -1
+        curr_loop_end = -1
+        step_num_is_non_empty_loop_start = set()
+        seq_num_is_adv_cycle_step = set()
+        seq_num_is_blank_loop = set()
+        step_num_by_seq_num = {}
+        for i, seq in enumerate(seqs):
+            seq_num = int(seq["Ns"])
+            loop_count = int(seq["ctrl_repeat"])
+            loop_to = int(seq["ctrl_seq"])
+            is_loop = seq["ctrl_type"] == "Loop"
+
+            if is_loop and loop_count == 0:
+                seq_num_is_blank_loop.update([seq_num])
+                continue
+            elif (
+                is_loop
+                and loop_to == seq_num - 1
+                and (seq_num - 1) in seq_num_is_blank_loop
+            ):
+                seq_num_is_adv_cycle_step.update([seq_num])
+                # add adv cycle step
+                step_num_by_seq_num.update({seq_num: curr_step})
+                curr_step += 1
+                continue
+
+            if seq_num in seq_num_is_non_empty_loop_start:
+                loop_active = True
+                curr_loop_start, curr_loop_end = containing_loop_range_by_seq_num[
+                    seq_num
+                ]
+                # add do step
+                curr_step += 1
+                step_num_is_non_empty_loop_start.update([curr_step])
+                seq_num_is_non_empty_loop_start.update([seq_num])
+            if loop_active is True:
+                step_num_is_non_empty_loop_start.update({seq_num: curr_loop_start})
+
+            step_num_by_seq_num[seq_num] = curr_step
+            if is_loop and loop_to == i - 1 and (i - 1) in seq_num_is_blank_loop:
+                # will adv cycle
+                curr_step += 1
+            elif is_loop and seqs[loop_to]["ctrl_type"] == "Loop":
+                raise Exception(
+                    "unhandled looping construct at seq {}, cannot loop to empty loop".format(
+                        seq_num
+                    )
+                    + "\nthat is not immediately followed by a cycle that loops back"
+                    + "\nto it (used to force a cycle advance)"
+                )
+            elif is_loop:
+                loop_active = False
+                # will adv cycle and loop
+                curr_step += 2
+            else:
+                # add normal step
+                curr_step += 1
+
+        end_step_num = curr_step
+
+        # check for illegal GOTOs
+        #
+        # Maccor explicitly disallows us to enter a loop from outside a loop (other than to start one)
+        # and going back before a loop end is similarly illegal
+        steps = []
+        last_loop_end = -1
+        for seq in seqs:
+            seq_num = int(seq["Ns"])
+            num_limits = int(seq["lim_nb"])
+
+            if seq_num in seq_num_is_blank_loop:
+                continue
+            if seq["ctrl_type"] == "Loop":
+                last_loop_end = seq_num
+                continue
+
+            seq_belongs_to_loop = seq_num in containing_loop_range_by_seq_num
+
+            for lim in range(1, num_limits + 1):
+                goto = int(seq["lim{}_seq".format(lim)])
+                if goto < last_loop_end:
+                    raise Exception(
+                        "Illegal GOTO at lim{}_seq, at seq {}\n".format(lim, seq_num)
+                        + "\ncannot GOTO any seq that occurs before the end an earlier non-empty loop"
+                        + "\nthere was a loop end at seq {}".format(last_loop_end)
+                    )
+
+                goto_belongs_to_loop = goto in containing_loop_range_by_seq_num
+                goto_is_start_of_loop = (
+                    goto == containing_loop_range_by_seq_num[goto][0]
+                    if goto_belongs_to_loop
+                    else False
+                )
+
+                if seq_belongs_to_loop and goto_belongs_to_loop:
+                    goto_loop_start, goto_loop_end = containing_loop_range_by_seq_num[
+                        goto
+                    ]
+                    seq_loop_start, seq_loop_end = containing_loop_range_by_seq_num[
+                        seq_num
+                    ]
+                    if (
+                        goto_loop_start != seq_loop_start
+                        or goto_loop_end != seq_loop_end
+                    ):
+                        raise Exception(
+                            "Illegal GOTO at lim{}_seq: {} at seq {}".format(
+                                lim, goto, seq_num
+                            )
+                            + "\nas {} is contained in loop range {}-{}".format(
+                                goto, goto_loop_start, goto_loop_end
+                            )
+                            + "\nMaccor only allows you to GOTO the interior of a loop from inside the same loop"
+                            + "\notherwise you must goto the start of the loop, seq: {}".format(
+                                goto_loop_start
+                            )
+                        )
+                if (
+                    not seq_belongs_to_loop
+                    and goto_belongs_to_loop
+                    and not goto_is_start_of_loop
+                ):
+                    goto_loop_start, goto_loop_end = containing_loop_range_by_seq_num[
+                        goto
+                    ]
+                    raise Exception(
+                        "Illegal goto at lim{}_seq: {} at seq {}".format(
+                            lim, goto, seq_num
+                        )
+                        + "\nMaccor only allows you to GOTO the interior of a loop from inside the same loop"
+                        + "\nthe loop. Seq {} is in the loop from {}-{} ".format(
+                            goto, goto_loop_start, goto_loop_end
+                        )
+                        + "\nSeq{} is not contained in a loop".format(seq)
+                        + "\nYou can only goto the start of the loop, seq {}.".format(
+                            goto_loop_start
+                        )
+                    )
+
+        # tightly coupled with the loop that constructs the seq num/step num mapping
+        steps = []
+        for i, seq in enumerate(seqs):
+            seq_num = int(seq["Ns"])
+            seq_is_loop = seq["ctrl_type"] == "Loop"
+            loop_to = int(seq["ctrl_seq"])
+
+            if seq_num in seq_num_is_blank_loop:
+                continue
+
+            if seq_num in seq_num_is_non_empty_loop_start:
+                do_step = cls._create_do_step()
+                steps.append(do_step)
+
+            if (
+                seq_is_loop
+                and loop_to == seq_num - 1
+                and seq_num - 1 in seq_num_is_blank_loop
+            ):
+                adv_cycle_step = cls._create_adv_cycle_step()
+                steps.append(adv_cycle_step)
+            elif seq_is_loop:
+                adv_cycle_step = cls._create_adv_cycle_step()
+                steps.append(adv_cycle_step)
+
+                loop_step = cls._create_loop_step(seq, step_num_by_seq_num)
+                steps.append(loop_step)
+            else:
+                step = cls._create_step(
+                    seq,
+                    step_num_by_seq_num,
+                    step_num_is_non_empty_loop_start,
+                    end_step_num,
+                )
+                steps.append(step)
+
+        end_step = deepcopy(_blank_step)
+        end_step["StepType"] = "  End   "
+        end_step["StepMode"] = "        "
+        steps.append(end_step)
+
+        return steps

--- a/beep/protocol/biologic_mb_to_maccor.py
+++ b/beep/protocol/biologic_mb_to_maccor.py
@@ -227,7 +227,7 @@ class BiologicMbToMaccorProcedure:
             )
 
     @classmethod
-    def _create_loop_step(cls, seq, seq_num_by_step_num):
+    def _create_loop_step(cls, seq, step_num_by_seq_num):
         step = deepcopy(_blank_step)
         # spacing may be important
         step["StepType"] = " Loop 1 "
@@ -238,7 +238,9 @@ class BiologicMbToMaccorProcedure:
 
         loop_count = int(seq["ctrl_repeat"])
         loop_to_seq = int(seq["ctrl_seq"])
-        loop_to_step = seq_num_by_step_num[loop_to_seq]
+        # Maccor requires us to loop to the DO step
+        # not the actual procedural step like in Biologic seqs
+        loop_to_step = step_num_by_seq_num[loop_to_seq] - 1
 
         loop_end_entry["EndType"] = "Loop Cnt"
         loop_end_entry["Oper"] = " = "

--- a/beep/protocol/biologic_mb_to_maccor.py
+++ b/beep/protocol/biologic_mb_to_maccor.py
@@ -39,7 +39,7 @@ class BiologicMbToMaccorProcedure:
             (optional) mps_file_encoding(str): text encoding of *.mps
             (optional) maccor_header(OrderedDict): This defines the shape of the <header> in
                 the output file
-            
+
         Returns: None on success, otherwise throws an error
         """
         if not os.path.isfile(mps_filepath):
@@ -55,9 +55,8 @@ class BiologicMbToMaccorProcedure:
 
         with open(out_filepath, "w+") as out_file:
             out_file.write(protocol_xml)
-        
-        return None
 
+        return None
 
     """
     Biologic Modulo Bat text ingestion from
@@ -65,10 +64,11 @@ class BiologicMbToMaccorProcedure:
 
     Args:
         text (str): the text from a *.mps file
-        
+
     Returns:
         (xml): string containing the XML for a Maccor Procedure
     """
+
     @classmethod
     def biologic_mb_text_to_maccor_xml(
         cls, mps_text, maccor_header=_default_maccor_header
@@ -98,7 +98,6 @@ class BiologicMbToMaccorProcedure:
         # newline at EOF
         return xml_with_maccor_processing_instruction + newLine
 
-
     @classmethod
     def _get_seqs(cls, shcedule_dict):
         techniques = shcedule_dict["Technique"]
@@ -109,7 +108,7 @@ class BiologicMbToMaccorProcedure:
 
         # Steps are equivelant to seqs
         numbered_seqs = list(modulo_bat["Step"].items())
-   
+
         # biologic parser may create empty seq(s) at the end
         # we intentionally _don't_ filter because if there is
         # a blank seq at in the middle

--- a/beep/tests/test_biologic_mb_to_maccor.py
+++ b/beep/tests/test_biologic_mb_to_maccor.py
@@ -1,5 +1,12 @@
 import unittest
+import os
 from beep.protocol.biologic_mb_to_maccor import BiologicMbToMaccorProcedure
+from beep.tests.test_files.biologic_mb_test_strs import SAMPLE_MB_TEXT, EXPECTED_XML
+
+TEST_DIR = os.path.dirname(__file__)
+TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
+SAMPLE_MB_FILE_NAME = "BCS - 171.64.160.115_Ta19_ourprotocol_gdocSEP2019_CC7.mps"
+CONVERTED_OUTPUT_FILE_NAME = "test_biologic_mb_to_maccor_output_diagnostic"
 
 
 class BiologicMbToMaccorTest(unittest.TestCase):
@@ -310,3 +317,20 @@ class BiologicMbToMaccorTest(unittest.TestCase):
         }
 
         self._test_step_helper(expected_constant_current_step, constant_current_step)
+
+    def test_biologic_mb_text_to_maccor_xml(self):
+        xml = BiologicMbToMaccorProcedure.biologic_mb_text_to_maccor_xml(SAMPLE_MB_TEXT)
+        xml_lines = xml.splitlines()
+        expected_xml_lines = EXPECTED_XML.splitlines()
+        for line_num in range(len(expected_xml_lines)):
+            assert line_num < len(xml_lines)
+            self.assertEqual(expected_xml_lines[line_num], xml_lines[line_num])
+
+    def test_convert(self):
+        # TODO
+        #
+        # Assert equivalence to a verified file
+        source = os.path.join(TEST_FILE_DIR, SAMPLE_MB_FILE_NAME)
+        target = os.path.join(TEST_FILE_DIR, CONVERTED_OUTPUT_FILE_NAME)
+        BiologicMbToMaccorProcedure.convert(source, target)
+        os.remove(target)

--- a/beep/tests/test_files/biologic_mb_test_strs.py
+++ b/beep/tests/test_files/biologic_mb_test_strs.py
@@ -36,7 +36,7 @@ ctrl2_val_unit
 ctrl2_val_vs                                                                                        
 ctrl3_val           1.700               1.700               1.700               1.700               
 ctrl3_val_unit      1.700               1.700               1.700               1.700               
-ctrl3_val_vs        1.700               1.700               1.700               1.700               
+ctrl3_val_vs        1.700               1.700               1t.700               1.700               
 N                   0.00                0.01                0.01                0.01                
 charge/discharge    Charge              Charge              Charge              Charge              
 ctrl_seq            0                   0                   0                   0                   
@@ -209,7 +209,7 @@ EXPECTED_XML = """<?xml version="1.0" encoding="UTF-8"?>
           <EndType>Loop Cnt</EndType>
           <SpecialType> </SpecialType>
           <Oper> = </Oper>
-          <Step>002</Step>
+          <Step>001</Step>
           <Value></Value>
           <StepValue>5</StepValue>
         </EndEntry>

--- a/beep/tests/test_files/biologic_mb_test_strs.py
+++ b/beep/tests/test_files/biologic_mb_test_strs.py
@@ -1,0 +1,264 @@
+SAMPLE_MB_TEXT = """BT-LAB SETTING FILE
+
+Number of linked techniques : 1
+
+Filename : C:\\Users\\sample.mps
+
+Device : BCS-805
+Ecell ctrl range : min = 0.00 V, max = 10.00 V
+Electrode material : 
+Initial state : 
+Electrolyte : 
+Comments : 
+Mass of active material : 0.001 mg
+at x = 0.000
+Molecular weight of active material (at x = 0) : 0.001 g/mol
+Atomic weight of intercalated ion : 0.001 g/mol
+Acquisition started at : xo = 0.000
+Number of e- transfered per intercalated ion : 1
+for DX = 1, DQ = 26.802 mA.h
+Battery capacity : 2.280 mA.h
+Electrode surface area : 0.001 cm
+Characteristic mass : 9.130 mg
+Cycle Definition : Charge/Discharge alternance
+Turn to OCV between techniques
+
+Technique : 1
+Modulo Bat
+Ns                  0                   1                   2                   3                   
+ctrl_type           CV                  Rest                Loop                CR                  
+Apply I/C           C / N               I                   C / N               C / N               
+ctrl1_val           1.500                                                       1.500               
+ctrl1_val_unit      V                                                           Ohm                 
+ctrl1_val_vs        Ref                                                         <None>               
+ctrl2_val                                                                                           
+ctrl2_val_unit                                                                                      
+ctrl2_val_vs                                                                                        
+ctrl3_val           1.700               1.700               1.700               1.700               
+ctrl3_val_unit      1.700               1.700               1.700               1.700               
+ctrl3_val_vs        1.700               1.700               1.700               1.700               
+N                   0.00                0.01                0.01                0.01                
+charge/discharge    Charge              Charge              Charge              Charge              
+ctrl_seq            0                   0                   0                   0                   
+ctrl_repeat         0                   0                   5                   5                   
+ctrl_trigger        Rising Edge         Rising Edge         Rising Edge         Rising Edge         
+ctrl_TO_t           0.000               0.000               0.000               0.000               
+ctrl_TO_t_unit      s                   s                   s                   s                   
+ctrl_Nd             6                   6                   6                   6                   
+ctrl_Na             2                   2                   2                   2                   
+ctrl_corr           0                   0                   0                   0                   
+lim_nb              2                   2                   0                   1                   
+lim1_type           Time                Time                Time                Ecell               
+lim1_comp           >                   >                   >                   >                   
+lim1_Q              Q limit             Q limit             Q limit             Q limit             
+lim1_value          10.000              1.000               1.000               1.000               
+lim1_value_unit     s                   h                   h                   V                   
+lim1_action         Next sequence       Next sequence       Next sequence       Next sequence       
+lim1_seq            1                   2                   3                   4                   
+lim2_type           I                   I                   I                   I                   
+lim2_comp           <                   <                   <                   <                   
+lim2_Q              Q limit             Q limit             Q limit             Q limit             
+lim2_value          4.000               4.000               4.000               4.000               
+lim2_value_unit     mA                  mA                  mA                  mA                  
+lim2_action         Goto sequence       Goto sequence       Next sequence       Next sequence       
+lim2_seq            3                   1                   3                   3                   
+lim3_type           Time                Time                Time                Time                
+lim3_comp           <                   <                   <                   <                   
+lim3_Q              Q limit             Q limit             Q limit             Q limit             
+lim3_value          0.000               0.000               0.000               0.000               
+lim3_value_unit     s                   s                   s                   s                   
+lim3_action         Next sequence       Next sequence       Next sequence       Next sequence       
+lim3_seq            1                   1                   1                   1                   
+rec_nb              1                   1                   0                   1                   
+rec1_type           I                   Power               Power               Power               
+rec1_value          5.000               5.000               5.000               5.000               
+rec1_value_unit     µA                  W                   W                   W                   
+rec2_type           Time                Time                Time                Time                
+rec2_value          0.000               0.000               0.000               0.000               
+rec2_value_unit     s                   s                   s                   s                   
+rec3_type           Time                Time                Time                Time                
+rec3_value          0.000               0.000               0.000               0.000               
+rec3_value_unit     s                   s                   s                   s                   
+E range min (V)     -10.000             -10.000             -10.000             -10.000             
+E range max (V)     10.000              10.000              10.000              10.000              
+I Range             100 mA              1 A                 1 A                 100 mA              
+I Range min         Unset               Unset               Unset               Unset               
+I Range max         Unset               Unset               Unset               Unset               
+I Range init        Unset               Unset               Unset               Unset               
+auto rest           0                   0                   0                   0                   
+Bandwidth           5                   5                   5                   5                   
+"""
+
+EXPECTED_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<?maccor-application progid="Maccor Procedure File"?>
+<MaccorTestProcedure>
+  <header>
+    <BuildTestVersion>
+      <major>1</major>
+      <minor>5</minor>
+      <release>7006</release>
+      <build>32043</build>
+    </BuildTestVersion>
+    <FileFormatVersion>
+      <BTVersion>11</BTVersion>
+    </FileFormatVersion>
+    <ProcDesc>
+      <desc></desc>
+    </ProcDesc>
+  </header>
+  <ProcSteps>
+    <TestStep>
+      <StepType>  Do 1  </StepType>
+      <StepMode>        </StepMode>
+      <StepValue></StepValue>
+      <Limits/>
+      <Ends/>
+      <Reports/>
+      <Range></Range>
+      <Option1></Option1>
+      <Option2></Option2>
+      <Option3></Option3>
+      <StepNote></StepNote>
+    </TestStep>
+    <TestStep>
+      <StepType>Dischrge </StepType>
+      <StepMode>Voltage </StepMode>
+      <StepValue>1.500</StepValue>
+      <Limits/>
+      <Ends>
+        <EndEntry>
+          <EndType>StepTime</EndType>
+          <SpecialType> </SpecialType>
+          <Oper> = </Oper>
+          <Step>003</Step>
+          <Value>00:00:10.0</Value>
+        </EndEntry>
+        <EndEntry>
+          <EndType>Current </EndType>
+          <SpecialType> </SpecialType>
+          <Oper>&lt;= </Oper>
+          <Step>006</Step>
+          <Value>4.0E-3</Value>
+        </EndEntry>
+      </Ends>
+      <Reports>
+        <ReportEntry>
+          <ReportType>Current </ReportType>
+          <Value>5.0E-6</Value>
+        </ReportEntry>
+      </Reports>
+      <Range>4</Range>
+      <Option1>N</Option1>
+      <Option2>N</Option2>
+      <Option3>N</Option3>
+      <StepNote></StepNote>
+    </TestStep>
+    <TestStep>
+      <StepType>  Rest  </StepType>
+      <StepMode>        </StepMode>
+      <StepValue></StepValue>
+      <Limits/>
+      <Ends>
+        <EndEntry>
+          <EndType>StepTime</EndType>
+          <SpecialType> </SpecialType>
+          <Oper> = </Oper>
+          <Step>004</Step>
+          <Value>1.0:00:00</Value>
+        </EndEntry>
+        <EndEntry>
+          <EndType>Current </EndType>
+          <SpecialType> </SpecialType>
+          <Oper>&lt;= </Oper>
+          <Step>003</Step>
+          <Value>4.0E-3</Value>
+        </EndEntry>
+      </Ends>
+      <Reports>
+        <ReportEntry>
+          <ReportType>Power </ReportType>
+          <Value>5.0</Value>
+        </ReportEntry>
+      </Reports>
+      <Range>4</Range>
+      <Option1>N</Option1>
+      <Option2>N</Option2>
+      <Option3>N</Option3>
+      <StepNote></StepNote>
+    </TestStep>
+    <TestStep>
+      <StepType>AdvCycle</StepType>
+      <StepMode>        </StepMode>
+      <StepValue></StepValue>
+      <Limits/>
+      <Ends/>
+      <Reports/>
+      <Range></Range>
+      <Option1></Option1>
+      <Option2></Option2>
+      <Option3></Option3>
+      <StepNote></StepNote>
+    </TestStep>
+    <TestStep>
+      <StepType> Loop 1 </StepType>
+      <StepMode>        </StepMode>
+      <StepValue></StepValue>
+      <Limits/>
+      <Ends>
+        <EndEntry>
+          <EndType>Loop Cnt</EndType>
+          <SpecialType> </SpecialType>
+          <Oper> = </Oper>
+          <Step>002</Step>
+          <Value></Value>
+          <StepValue>5</StepValue>
+        </EndEntry>
+      </Ends>
+      <Reports/>
+      <Range></Range>
+      <Option1></Option1>
+      <Option2></Option2>
+      <Option3></Option3>
+      <StepNote></StepNote>
+    </TestStep>
+    <TestStep>
+      <StepType>Dischrge </StepType>
+      <StepMode>Resistance </StepMode>
+      <StepValue>1.500</StepValue>
+      <Limits/>
+      <Ends>
+        <EndEntry>
+          <EndType>Voltage </EndType>
+          <SpecialType> </SpecialType>
+          <Oper>&gt;= </Oper>
+          <Step>007</Step>
+          <Value>1.0</Value>
+        </EndEntry>
+      </Ends>
+      <Reports>
+        <ReportEntry>
+          <ReportType>Power </ReportType>
+          <Value>5.0</Value>
+        </ReportEntry>
+      </Reports>
+      <Range>4</Range>
+      <Option1>N</Option1>
+      <Option2>N</Option2>
+      <Option3>N</Option3>
+      <StepNote></StepNote>
+    </TestStep>
+    <TestStep>
+      <StepType>  End   </StepType>
+      <StepMode>        </StepMode>
+      <StepValue></StepValue>
+      <Limits/>
+      <Ends/>
+      <Reports/>
+      <Range></Range>
+      <Option1></Option1>
+      <Option2></Option2>
+      <Option3></Option3>
+      <StepNote></StepNote>
+    </TestStep>
+  </ProcSteps>
+"""


### PR DESCRIPTION
Here be dragons. 

This PR implements the structural transformations of a Biologic Modulo Bat protocol to an equivalent protocol in Maccor's Procedure format.

There are two main methods:
`convert` which intakes a file and writes a file
`biologic_mb_text_to_maccor_xml` which takes in the already loaded text from a file and returns the equivalent xml for Maccor.

There are a number of structural constraints that are imposed on all incoming files:
- Nested loops are forbidden, the way Maccor and Biologic implement nested loops is fundamentally incompatible as far as I can tell. From my reading a nested loop in Biologic will only loop over the inner loop during the _first_ loop of the outer loop. On subsequent iterations of the outer loop, the inner loop will run once. This is not representable on Maccor.
- In their documentation, Maccor forbids a GOTO into the the interior of a loop from outside that loop, you can only GOTO a "DO" step that begins a loop we also impose that constraint.
- In their documentation, Maccor forbids a GOTO that will move to a step before a completed loop, we also impose that constraint.

We provide helpful error messages in case of each of these violations.