### PR TITLE
Make changes so that paused is the number of seconds 

### DIFF
--- a/beep/structure.py
+++ b/beep/structure.py
@@ -457,7 +457,7 @@ class RawCyclerRun(MSONable):
         self.data.drop(columns=["time_since_cycle_start"])
 
         # Determine if any of the cycles has been paused
-        summary["paused"] = self.data.groupby("cycle_index").apply(determine_paused)
+        summary["paused"] = self.data.groupby("cycle_index").apply(get_max_paused_over_threshold)
 
         summary = summary.astype(STRUCTURE_DTYPES["summary"])
 
@@ -530,7 +530,7 @@ class RawCyclerRun(MSONable):
             diag_summary["discharge_capacity"] / diag_summary["charge_capacity"]
         )
         diag_summary["paused"] = self.data.groupby("cycle_index").apply(
-            determine_paused
+            get_max_paused_over_threshold
         )
 
         diag_summary.reset_index(drop=True, inplace=True)
@@ -2019,9 +2019,12 @@ def add_file_prefix_to_path(path, prefix):
     return os.path.join(*split_path)
 
 
-def determine_paused(group, paused_threshold=3600):
+def get_max_paused_over_threshold(group, paused_threshold=3600):
     """
-    Evaluate a raw cycling dataframe to determine if there is a pause in cycling
+    Evaluate a raw cycling dataframe to determine if there is a pause in cycling.
+    The method looks at the time difference between each row and if this value
+    exceeds a threshold, it returns that length of time in seconds. Otherwise it
+    returns 0
 
     Args:
         group (pd.DataFrame): cycling dataframe with date_time_iso column
@@ -2038,11 +2041,11 @@ def determine_paused(group, paused_threshold=3600):
     ]
     date_time_float = pd.Series(date_time_float)
     if date_time_float.diff().max() > paused_threshold:
-        paused_secs = date_time_float.diff().max()
+        max_paused_overthreshold = date_time_float.diff().max()
     else:
-        paused_secs = 0
+        max_paused_overthreshold = 0
 
-    return paused_secs
+    return max_paused_overthreshold
 
 
 def maccor_timestamp(x):

--- a/beep/structure.py
+++ b/beep/structure.py
@@ -2041,11 +2041,10 @@ def get_max_paused_over_threshold(group, paused_threshold=3600):
     ]
     date_time_float = pd.Series(date_time_float)
     if date_time_float.diff().max() > paused_threshold:
-        max_paused_overthreshold = date_time_float.diff().max()
+        max_paused_duration = date_time_float.diff().max()
     else:
-        max_paused_overthreshold = 0
-
-    return max_paused_overthreshold
+        max_paused_duration = 0
+    return max_paused_duration
 
 
 def maccor_timestamp(x):

--- a/beep/structure.py
+++ b/beep/structure.py
@@ -2028,7 +2028,7 @@ def determine_paused(group, paused_threshold=3600):
         paused_threshold (int): gap in seconds to classify as a pause in cycling
 
     Returns:
-        bool: is there a pause in this cycle?
+        float: number of seconds that test was paused
 
     """
     date_time_obj = pd.to_datetime(group["date_time_iso"])
@@ -2037,7 +2037,12 @@ def determine_paused(group, paused_threshold=3600):
         for t in date_time_obj
     ]
     date_time_float = pd.Series(date_time_float)
-    return int(date_time_float.diff().max() > paused_threshold)
+    if date_time_float.diff().max() > paused_threshold:
+        paused_secs = date_time_float.diff().max()
+    else:
+        paused_secs = 0
+
+    return paused_secs
 
 
 def maccor_timestamp(x):

--- a/beep/tests/test_structure.py
+++ b/beep/tests/test_structure.py
@@ -19,7 +19,7 @@ from beep.structure import (
     get_project_sequence,
     get_protocol_parameters,
     get_diagnostic_parameters,
-    determine_paused,
+    get_max_paused_over_threshold,
 )
 from beep.conversion_schemas import STRUCTURE_DTYPES
 from monty.serialization import loadfn, dumpfn
@@ -961,7 +961,7 @@ class RawCyclerRunTest(unittest.TestCase):
 
     def test_determine_paused(self):
         cycler_run = RawCyclerRun.from_file(self.maccor_file_paused)
-        paused = cycler_run.data.groupby("cycle_index").apply(determine_paused)
+        paused = cycler_run.data.groupby("cycle_index").apply(get_max_paused_over_threshold)
         self.assertEqual(paused.max(), 7201.0)
 
 

--- a/beep/tests/test_structure.py
+++ b/beep/tests/test_structure.py
@@ -962,7 +962,7 @@ class RawCyclerRunTest(unittest.TestCase):
     def test_determine_paused(self):
         cycler_run = RawCyclerRun.from_file(self.maccor_file_paused)
         paused = cycler_run.data.groupby("cycle_index").apply(determine_paused)
-        self.assertEqual(paused.max(), 1)
+        self.assertEqual(paused.max(), 7201.0)
 
 
 class CliTest(unittest.TestCase):


### PR DESCRIPTION
This PR changes the content of the paused metric in the summary to be the length of the gap between data points in seconds.