### PR TITLE
Create test and test file to resolve error

### DIFF
--- a/beep/features/featurizer_helpers.py
+++ b/beep/features/featurizer_helpers.py
@@ -600,7 +600,8 @@ def get_v_diff(processed_cycler_run, diag_pos, soc_window, baseline_step_index=1
         diag_pos (int): diagnostic cycle occurence for a specific <diagnostic_cycle_type>. e.g.
         if rpt_0.2C, occurs at cycle_index = [2, 37, 142, 244 ...], <diag_pos>=0 would correspond to cycle_index 2
         soc_window (int): step index counter corresponding to the soc window of interest.
-        baseline_step_index (int): step index of the initial hppc cycle (discharge
+        baseline_step_index (int): step index of the initial hppc cycle (TODO automatically get value in the method)
+        measured_step_index (int): step index of the comparison hppc cycle (TODO automatically get value in the method)
 
     Returns:
         a dataframe that contains the variance of the voltage differences
@@ -634,17 +635,14 @@ def get_v_diff(processed_cycler_run, diag_pos, soc_window, baseline_step_index=1
 
     V = chosen_1.voltage.values
     Q = chosen_1.discharge_capacity.values
+
+    #  Round values so that non-strictly monotonic values are removed
     np.around(Q, decimals=6, out=Q)
     np.around(V, decimals=6, out=V)
     if not np.all(np.diff(Q) > 0):
-        print("not monotonic")
-        print(np.shape(Q), np.shape(V))
-        index_of_repeated = np.where(abs(np.diff(Q)) == 0)[0]
-        print(index_of_repeated)
+        index_of_repeated = np.where(np.abs(np.diff(Q)) == 0)[0]
         Q = np.delete(Q, index_of_repeated, axis=0)
         V = np.delete(V, index_of_repeated, axis=0)
-        print(np.shape(Q), np.shape(V))
-        print(Q, V)
     f = interp1d(Q, V, kind="cubic", fill_value="extrapolate", assume_sorted=False)
 
     v_2 = chosen_2.voltage.tolist()

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -390,3 +390,24 @@ class TestFeaturizer(unittest.TestCase):
                              ['m0_Amp_rpt_0.2C_1', 'm0_Mu_rpt_0.2C_1', 'm1_Amp_rpt_0.2C_1',
                               'm1_Mu_rpt_0.2C_1', 'm2_Amp_rpt_0.2C_1', 'm2_Mu_rpt_0.2C_1',
                               'trough_height_0_rpt_0.2C_1', 'trough_height_1_rpt_0.2C_1'])
+
+    def test_get_v_diff(self):
+        processed_cycler_run_path_1 = os.path.join(
+            TEST_FILE_DIR, "Talos_001383_NCR18650618001_CH31_truncated_structure.json"
+        )
+        processed_cycler_run_path_2 = os.path.join(
+            TEST_FILE_DIR, "PreDiag_000304_000153_truncated_structure.json"
+        )
+        with ScratchDir("."):
+            os.environ["BEEP_PROCESSING_DIR"] = TEST_FILE_DIR
+            pcycler_run = loadfn(processed_cycler_run_path_1)
+            v_vars_df = featurizer_helpers.get_v_diff(pcycler_run, 1, 8)
+            print(v_vars_df)
+            self.assertEqual(np.round(v_vars_df.iloc[0]['var(v_diff)'], decimals=8),
+                             np.round(0.00850563, decimals=8))
+
+            pcycler_run = loadfn(processed_cycler_run_path_2)
+            v_vars_df = featurizer_helpers.get_v_diff(pcycler_run, 1, 8)
+            print(v_vars_df)
+            self.assertEqual(np.round(v_vars_df.iloc[0]['var(v_diff)'], decimals=8),
+                             np.round(2.664685514952474e-05, decimals=8))


### PR DESCRIPTION
This PR resolves a problem with the `get_v_diff` function used in featurization. For some files the change in the interpolation axis from point to point to smaller than the floating point precision used in `interp1d` This results in the interpolation failing due to a non-strict monotonic trend in the axis `ValueError: Expect x to be a 1-D sorted array_like.`
- Added a test file where this problem occurs.
- Changed the method to remove redundant points when they exist
- Added a test with a file that does cause the error and file that does not to ensure that values are not changed due to the alteration in the method.