### PR TITLE
MAT-2042: Setup Coverage Config

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = beep/tests/*

--- a/.github/workflows/beep-lint.yml
+++ b/.github/workflows/beep-lint.yml
@@ -11,26 +11,26 @@ jobs:
         python-version: [3.7]
 
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-    - name: pycodestyle
-      run: |
-        pip install pycodestyle --upgrade --quiet
-        pycodestyle beep
-    - name: flake8
-      run: |
-        pip install flake8 --upgrade --quiet
-        flake8 --count --show-source --statistics beep
-        # exit-zero treats all errors as warnings.
-        flake8 --count --exit-zero --max-complexity=20 --statistics beep
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+      - name: pycodestyle
+        run: |
+          pip install pycodestyle --upgrade --quiet
+          pycodestyle beep
+      - name: flake8
+        run: |
+          pip install flake8 --upgrade --quiet
+          flake8 --count --show-source --statistics beep
+          # exit-zero treats all errors as warnings.
+          flake8 --count --exit-zero --max-complexity=20 --statistics beep
     # Note: enable this when docstrings are ready
     # - name: pydocstyle
     #   run: |

--- a/.github/workflows/beep-test-pr.yml
+++ b/.github/workflows/beep-test-pr.yml
@@ -6,41 +6,36 @@ on:
 
 jobs:
   test:
-
     strategy:
       max-parallel: 20
       matrix:
-        os: [
-          ubuntu-latest,
-          macos-latest,
-          windows-latest
-        ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7]
 
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -e .[tests]
-    - name: pytest
-      env:
-        MPLBACKEND: "Agg"
-        BEEP_ENV: "dev"
-      run: |
-        pytest beep --color=yes --cov=beep --cov-report html:coverage_reports
-    - name: Coveralls
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        coveralls
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .[tests]
+      - name: pytest
+        env:
+          MPLBACKEND: "Agg"
+          BEEP_ENV: "dev"
+        run: |
+          pytest beep --color=yes --cov=beep --cov-report html:coverage_reports
+      - name: Coveralls
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          coveralls

--- a/.github/workflows/beep-test-pr.yml
+++ b/.github/workflows/beep-test-pr.yml
@@ -33,7 +33,7 @@ jobs:
           MPLBACKEND: "Agg"
           BEEP_ENV: "dev"
         run: |
-          pytest beep --color=yes --cov=beep --cov-report html:coverage_reports
+          pytest beep --color=yes --cov=beep --cov-config=.coveragerc --cov-report html:coverage_reports
       - name: Coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/beep-test.yml
+++ b/.github/workflows/beep-test.yml
@@ -6,49 +6,44 @@ on:
 
 jobs:
   test:
-
     strategy:
       max-parallel: 20
       matrix:
-        os: [
-          ubuntu-latest,
-          macos-latest,
-          windows-latest
-        ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7]
 
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-west-2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -e .[tests]
-    - name: pytest
-      env:
-        MPLBACKEND: "Agg"
-        BEEP_ENV: "dev"
-      run: |
-        pytest beep --color=yes --cov=beep --cov-report html:coverage_reports
-    - name: Coveralls
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BEEP_BIG_TESTS: "True"
-      run: |
-        coveralls
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .[tests]
+      - name: pytest
+        env:
+          MPLBACKEND: "Agg"
+          BEEP_ENV: "dev"
+        run: |
+          pytest beep --color=yes --cov=beep --cov-report html:coverage_reports
+      - name: Coveralls
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BEEP_BIG_TESTS: "True"
+        run: |
+          coveralls

--- a/.github/workflows/beep-test.yml
+++ b/.github/workflows/beep-test.yml
@@ -40,7 +40,7 @@ jobs:
           MPLBACKEND: "Agg"
           BEEP_ENV: "dev"
         run: |
-          pytest beep --color=yes --cov=beep --cov-report html:coverage_reports
+          pytest beep --color=yes --cov=beep --cov-config=.coveragerc --cov-report html:coverage_reports
       - name: Coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,8 @@ addopts = --durations=30 --quiet
 filterwarnings =
     ignore::UserWarning
     ignore::RuntimeWarning
+testpaths = 
+    beep/tests
 
 [pycodestyle]
 count = True


### PR DESCRIPTION
This PR sets up pytest to ignore test files in the coverage report.

Note: Coverage has decreased and it appears that [`/beep/utils/secrets_manager.py:55`](https://coveralls.io/builds/34090576/source?filename=beep%2Futils%2Fsecrets_manager.py#L55) may be the cause. It looks like this line is covered in tests on the master branch, but not in PR branches. 