### PR TITLE
Fix arbin metadata requirement

### DIFF
--- a/beep/structure.py
+++ b/beep/structure.py
@@ -723,7 +723,6 @@ class RawCyclerRun(MSONable):
         Returns:
             beep.structure.RawCyclerRun
         """
-        metadata_path = path.replace(".csv", "_Metadata.csv")
         data = pd.read_csv(path)
         data.rename(str.lower, axis="columns", inplace=True)
 
@@ -733,11 +732,19 @@ class RawCyclerRun(MSONable):
                     data[column] = data[column].astype(dtype)
 
         data.rename(ARBIN_CONFIG["data_columns"], axis="columns", inplace=True)
-        metadata = pd.read_csv(metadata_path)
-        metadata.rename(str.lower, axis="columns", inplace=True)
-        metadata.rename(ARBIN_CONFIG["metadata_fields"], axis="columns", inplace=True)
-        # Note the to_dict, which scrubs numpy typing
-        metadata = {col: item[0] for col, item in metadata.to_dict("list").items()}
+
+        metadata_path = path.replace(".csv", "_Metadata.csv")
+
+        if os.path.exists(metadata_path):
+            metadata = pd.read_csv(metadata_path)
+            metadata.rename(str.lower, axis="columns", inplace=True)
+            metadata.rename(ARBIN_CONFIG["metadata_fields"], axis="columns", inplace=True)
+            # Note the to_dict, which scrubs numpy typing
+            metadata = {col: item[0] for col, item in metadata.to_dict("list").items()}
+        else:
+            logger.warning(f"No associated metadata file for Arbin: "
+                           f"'{metadata_path}'. No metadata loaded.")
+            metadata = {}
 
         # standardizing time format
         data["date_time_iso"] = data["date_time"].apply(


### PR DESCRIPTION
Fix #122 

Previously:
- Arbin metadata file was only nominally required for using RawCyclerRun

Now:
- Arbin metadata is not required, empty metadata is provided if no _Metadata is found
- a warning is thrown via logging to warn user the metadata file is not present