### PR TITLE
add filters for waveform discharge and charge

### DIFF
--- a/beep/structure.py
+++ b/beep/structure.py
@@ -1812,8 +1812,7 @@ class EISpectrum(MSONable):
 def determine_whether_step_is_waveform_discharge(step_dataframe):
     """
     Helper function for driving profiles to determine whether a given dataframe corresponding
-    to a single cycle_index/step has both charging and discharging portions, only intended
-    to be used with a dataframe for single maccor step/cycle.
+    to a single cycle_index/step is a waveform discharge.
 
     Args:
          step_dataframe (pandas.DataFrame): dataframe to determine whether waveform step is present
@@ -1840,8 +1839,7 @@ def determine_whether_step_is_waveform_discharge(step_dataframe):
 def determine_whether_step_is_waveform_charge(step_dataframe):
     """
     Helper function for driving profiles to determine whether a given dataframe corresponding
-    to a single cycle_index/step has both charging and discharging portions, only intended
-    to be used with a dataframe for single maccor step/cycle.
+    to a single cycle_index/step is a waveform charge.
 
     Args:
          step_dataframe (pandas.DataFrame): dataframe to determine whether waveform step is present

--- a/beep/tests/test_structure.py
+++ b/beep/tests/test_structure.py
@@ -31,7 +31,8 @@ from beep.structure import (
     get_project_sequence,
     get_protocol_parameters,
     get_diagnostic_parameters,
-    determine_whether_step_is_waveform,
+    determine_whether_step_is_waveform_discharge,
+    determine_whether_step_is_waveform_charge,
     get_max_paused_over_threshold
 )
 from beep.conversion_schemas import STRUCTURE_DTYPES
@@ -365,9 +366,11 @@ class RawCyclerRunTest(unittest.TestCase):
     def test_whether_step_is_waveform(self):
         cycler_run = RawCyclerRun.from_file(self.maccor_file_w_waveform)
         self.assertTrue(cycler_run.data.loc[cycler_run.data.cycle_index == 6].
-                        groupby("step_index").apply(determine_whether_step_is_waveform).any())
+                        groupby("step_index").apply(determine_whether_step_is_waveform_discharge).any())
+        self.assertFalse(cycler_run.data.loc[cycler_run.data.cycle_index == 6].
+                        groupby("step_index").apply(determine_whether_step_is_waveform_charge).any())
         self.assertFalse(cycler_run.data.loc[cycler_run.data.cycle_index == 3].
-                        groupby("step_index").apply(determine_whether_step_is_waveform).any())
+                        groupby("step_index").apply(determine_whether_step_is_waveform_discharge).any())
 
 
     def test_get_interpolated_waveform_discharge_cycles(self):


### PR DESCRIPTION
Quick PR splits `determine_whether_step_is_waveform` into separate method for waveform discharge and waveform charge.