### PR TITLE
Fix structuring and throughput feature

### DIFF
--- a/beep/dataset.py
+++ b/beep/dataset.py
@@ -33,7 +33,7 @@ from monty.json import MSONable
 from monty.serialization import loadfn, dumpfn
 from functools import reduce
 from beep import MODULE_DIR
-from beep.structure import get_protocol_parameters
+from beep.utils import parameters_lookup
 from beep.featurize import (
     RPTdQdVFeatures, HPPCResistanceVoltageFeatures,
     HPPCRelaxationFeatures, DiagnosticProperties,
@@ -342,6 +342,6 @@ def get_parameter_dict(file_list, parameters_path):
     """
     d = {}  # dict allows combining two different project parameter sets into the same structure
     for file in file_list:
-        param_row, _ = get_protocol_parameters(file, parameters_path)
+        param_row, _ = parameters_lookup.get_protocol_parameters(file, parameters_path)
         d[file] = param_row.to_dict('records')[0]  # to_dict('records') returns a list.
     return d

--- a/beep/structure.py
+++ b/beep/structure.py
@@ -372,7 +372,7 @@ class RawCyclerRun(MSONable):
 
     def get_summary(
         self,
-        diagnostic_available=None,
+        diagnostic_available=False,
         nominal_capacity=1.1,
         full_fast_charge=0.8,
         cycle_complete_discharge_ratio=0.97,
@@ -1458,7 +1458,8 @@ class ProcessedCyclerRun(MSONable):
             raw_cycler_run.metadata.get("protocol"),
             raw_cycler_run.metadata.get("channel_id"),
             raw_cycler_run.get_summary(
-                nominal_capacity=nominal_capacity, full_fast_charge=full_fast_charge
+                nominal_capacity=nominal_capacity, full_fast_charge=full_fast_charge,
+                diagnostic_available=diagnostic_available
             ),
             cycles_interpolated,
             diagnostic_summary,

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -209,7 +209,8 @@ class TestFeaturizer(unittest.TestCase):
             self.assertIsInstance(features_reloaded, DiagnosticProperties)
             self.assertListEqual(
                 list(features_reloaded.X.iloc[2, :]),
-                [141, 0.9859837086597274, 91.17758004259996, 2.578137278917377, 'reset', 'discharge_energy'],
+                [141, 0.9859837086597274, 7.885284043, 4.323121513988055,
+                 21.12108276469096, 30, 100, 'reset', 'discharge_energy'],
             )
 
             # Workflow output
@@ -367,10 +368,12 @@ class TestFeaturizer(unittest.TestCase):
             folder = os.path.split(path)[-1]
             dumpfn(featurizer, featurizer.name)
             self.assertEqual(folder, "DiagnosticProperties")
-            self.assertEqual(featurizer.X.shape, (30, 6))
+            self.assertEqual(featurizer.X.shape, (30, 9))
+            print(list(featurizer.X.iloc[2, :]))
             self.assertListEqual(
                 list(featurizer.X.iloc[2, :]),
-                [141, 0.9859837086597274, 91.17758004259996, 2.578137278917377, 'reset', 'discharge_energy']
+                [141, 0.9859837086597274, 7.885284043, 4.323121513988055,
+                 21.12108276469096, 30, 100, 'reset', 'discharge_energy']
             )
 
     def test_get_fractional_quantity_remaining_nx(self):
@@ -379,25 +382,27 @@ class TestFeaturizer(unittest.TestCase):
         )
         pcycler_run = loadfn(processed_cycler_run_path)
         pcycler_run.summary = pcycler_run.summary[~pcycler_run.summary.cycle_index.isin(pcycler_run.diagnostic_summary.cycle_index)]
-        print(pcycler_run.summary.cycle_index)
+        # print(pcycler_run.summary.cycle_index)
+        os.environ["BEEP_PROCESSING_DIR"] = TEST_FILE_DIR
+        # test_param_path = os.path.join(TEST_FILE_DIR, "data-share", "raw", "parameters")
         sum_diag = featurizer_helpers.get_fractional_quantity_remaining_nx(pcycler_run,
                                                                            metric="discharge_energy",
                                                                            diagnostic_cycle_type="hppc")
         print(sum_diag["normalized_regular_throughput"])
         self.assertEqual(len(sum_diag.index), 16)
         self.assertEqual(sum_diag.cycle_index.max(), 1507)
-        self.assertEqual(np.around(sum_diag["initial_regular_throughput"].iloc[0], 3), np.around(254.3685238364, 3))
-        self.assertEqual(np.around(sum_diag["normalized_regular_throughput"].iloc[15], 3), np.around(42.131, 3))
-        self.assertEqual(np.around(sum_diag["normalized_diagnostic_throughput"].iloc[15], 3), np.around(4.75, 3))
+        self.assertEqual(np.around(sum_diag["initial_regular_throughput"].iloc[0], 3), np.around(237.001769, 3))
+        self.assertEqual(np.around(sum_diag["normalized_regular_throughput"].iloc[15], 3), np.around(45.145, 3))
+        self.assertEqual(np.around(sum_diag["normalized_diagnostic_throughput"].iloc[15], 3), np.around(5.098, 3))
 
         sum_diag = featurizer_helpers.get_fractional_quantity_remaining_nx(pcycler_run,
                                                                            metric="discharge_energy",
                                                                            diagnostic_cycle_type="rpt_1C")
         self.assertEqual(len(sum_diag.index), 16)
         self.assertEqual(sum_diag.cycle_index.max(), 1509)
-        self.assertEqual(np.around(sum_diag["initial_regular_throughput"].iloc[0], 3), np.around(320.629961, 3))
-        self.assertEqual(np.around(sum_diag["normalized_regular_throughput"].iloc[15], 3), np.around(37.241178, 3))
-        self.assertEqual(np.around(sum_diag["normalized_diagnostic_throughput"].iloc[15], 3), np.around(37.241178, 3))
+        self.assertEqual(np.around(sum_diag["initial_regular_throughput"].iloc[0], 3), np.around(237.001769, 3))
+        self.assertEqual(np.around(sum_diag["normalized_regular_throughput"].iloc[15], 3), np.around(45.145, 3))
+        self.assertEqual(np.around(sum_diag["normalized_diagnostic_throughput"].iloc[15], 3), np.around(5.229, 3))
 
     def test_generate_dQdV_peak_fits(self):
         processed_cycler_run_path = os.path.join(

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -378,13 +378,26 @@ class TestFeaturizer(unittest.TestCase):
             TEST_FILE_DIR, "PreDiag_000233_00021F_truncated_structure.json"
         )
         pcycler_run = loadfn(processed_cycler_run_path)
+        pcycler_run.summary = pcycler_run.summary[~pcycler_run.summary.cycle_index.isin(pcycler_run.diagnostic_summary.cycle_index)]
+        print(pcycler_run.summary.cycle_index)
         sum_diag = featurizer_helpers.get_fractional_quantity_remaining_nx(pcycler_run,
                                                                            metric="discharge_energy",
                                                                            diagnostic_cycle_type="hppc")
+        print(sum_diag["normalized_regular_throughput"])
         self.assertEqual(len(sum_diag.index), 16)
         self.assertEqual(sum_diag.cycle_index.max(), 1507)
-        self.assertEqual(np.around(sum_diag.x.iloc[0], 3), np.around(320.629961, 3))
-        self.assertEqual(np.around(sum_diag.n.iloc[15], 3), np.around(37.241178, 3))
+        self.assertEqual(np.around(sum_diag["initial_regular_throughput"].iloc[0], 3), np.around(254.3685238364, 3))
+        self.assertEqual(np.around(sum_diag["normalized_regular_throughput"].iloc[15], 3), np.around(42.131, 3))
+        self.assertEqual(np.around(sum_diag["normalized_diagnostic_throughput"].iloc[15], 3), np.around(4.75, 3))
+
+        sum_diag = featurizer_helpers.get_fractional_quantity_remaining_nx(pcycler_run,
+                                                                           metric="discharge_energy",
+                                                                           diagnostic_cycle_type="rpt_1C")
+        self.assertEqual(len(sum_diag.index), 16)
+        self.assertEqual(sum_diag.cycle_index.max(), 1509)
+        self.assertEqual(np.around(sum_diag["initial_regular_throughput"].iloc[0], 3), np.around(320.629961, 3))
+        self.assertEqual(np.around(sum_diag["normalized_regular_throughput"].iloc[15], 3), np.around(37.241178, 3))
+        self.assertEqual(np.around(sum_diag["normalized_diagnostic_throughput"].iloc[15], 3), np.around(37.241178, 3))
 
     def test_generate_dQdV_peak_fits(self):
         processed_cycler_run_path = os.path.join(

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -394,6 +394,8 @@ class TestFeaturizer(unittest.TestCase):
         self.assertEqual(np.around(sum_diag["initial_regular_throughput"].iloc[0], 3), np.around(237.001769, 3))
         self.assertEqual(np.around(sum_diag["normalized_regular_throughput"].iloc[15], 3), np.around(45.145, 3))
         self.assertEqual(np.around(sum_diag["normalized_diagnostic_throughput"].iloc[15], 3), np.around(5.098, 3))
+        self.assertEqual(sum_diag['diagnostic_start_cycle'].iloc[0], 30)
+        self.assertEqual(sum_diag['diagnostic_interval'].iloc[0], 100)
 
         sum_diag = featurizer_helpers.get_fractional_quantity_remaining_nx(pcycler_run,
                                                                            metric="discharge_energy",
@@ -403,6 +405,8 @@ class TestFeaturizer(unittest.TestCase):
         self.assertEqual(np.around(sum_diag["initial_regular_throughput"].iloc[0], 3), np.around(237.001769, 3))
         self.assertEqual(np.around(sum_diag["normalized_regular_throughput"].iloc[15], 3), np.around(45.145, 3))
         self.assertEqual(np.around(sum_diag["normalized_diagnostic_throughput"].iloc[15], 3), np.around(5.229, 3))
+        self.assertEqual(sum_diag['diagnostic_start_cycle'].iloc[0], 30)
+        self.assertEqual(sum_diag['diagnostic_interval'].iloc[0], 100)
 
     def test_generate_dQdV_peak_fits(self):
         processed_cycler_run_path = os.path.join(

--- a/beep/tests/test_structure.py
+++ b/beep/tests/test_structure.py
@@ -28,13 +28,11 @@ from beep.structure import (
     ProcessedCyclerRun,
     process_file_list_from_json,
     EISpectrum,
-    get_project_sequence,
-    get_protocol_parameters,
-    get_diagnostic_parameters,
     determine_whether_step_is_waveform_discharge,
     determine_whether_step_is_waveform_charge,
     get_max_paused_over_threshold
 )
+from beep.utils import parameters_lookup
 from beep.conversion_schemas import STRUCTURE_DTYPES
 from monty.serialization import loadfn, dumpfn
 from monty.tempfile import ScratchDir
@@ -305,7 +303,6 @@ class RawCyclerRunTest(unittest.TestCase):
             )
         )
 
-
     def test_get_interpolated_discharge_cycles(self):
         cycler_run = RawCyclerRun.from_file(self.arbin_file)
         all_interpolated = cycler_run.get_interpolated_cycles()
@@ -372,7 +369,6 @@ class RawCyclerRunTest(unittest.TestCase):
         self.assertFalse(cycler_run.data.loc[cycler_run.data.cycle_index == 3].
                         groupby("step_index").apply(determine_whether_step_is_waveform_discharge).any())
 
-
     def test_get_interpolated_waveform_discharge_cycles(self):
         cycler_run = RawCyclerRun.from_file(self.maccor_file_w_waveform)
         all_interpolated = cycler_run.get_interpolated_cycles()
@@ -383,7 +379,6 @@ class RawCyclerRunTest(unittest.TestCase):
                          cycler_run.data.loc[(cycler_run.data.cycle_index == 6) &
                                              (cycler_run.data.step_index == 33)].test_time.min())
         self.assertEqual(subset_interpolated[subset_interpolated.cycle_index == 6].shape[0], 1000)
-
 
     def test_get_interpolated_charge_cycles(self):
         cycler_run = RawCyclerRun.from_file(self.arbin_file)
@@ -820,7 +815,7 @@ class RawCyclerRunTest(unittest.TestCase):
                          [2.3427])
 
     def test_get_project_name(self):
-        project_name_parts = get_project_sequence(
+        project_name_parts = parameters_lookup.get_project_sequence(
             os.path.join(TEST_FILE_DIR, "PredictionDiagnostics_000109_tztest.010")
         )
         project_name = project_name_parts[0]
@@ -832,21 +827,21 @@ class RawCyclerRunTest(unittest.TestCase):
             TEST_FILE_DIR, "PredictionDiagnostics_000109_tztest.010"
         )
         test_path = os.path.join("data-share", "raw", "parameters")
-        parameters, _ = get_protocol_parameters(filepath, parameters_path=test_path)
+        parameters, _ = parameters_lookup.get_protocol_parameters(filepath, parameters_path=test_path)
 
         self.assertEqual(parameters["diagnostic_type"].iloc[0], "HPPC+RPT")
         self.assertEqual(parameters["diagnostic_parameter_set"].iloc[0], "Tesla21700")
         self.assertEqual(parameters["seq_num"].iloc[0], 109)
         self.assertEqual(len(parameters.index), 1)
 
-        parameters_missing, project_missing = get_protocol_parameters(
+        parameters_missing, project_missing = parameters_lookup.get_protocol_parameters(
             "Fake", parameters_path=test_path
         )
         self.assertEqual(parameters_missing, None)
         self.assertEqual(project_missing, None)
 
         filepath = os.path.join(TEST_FILE_DIR, "PreDiag_000292_tztest.010")
-        parameters, _ = get_protocol_parameters(filepath, parameters_path=test_path)
+        parameters, _ = parameters_lookup.get_protocol_parameters(filepath, parameters_path=test_path)
         self.assertIsNone(parameters)
 
     def test_determine_structering_parameters(self):
@@ -983,7 +978,7 @@ class RawCyclerRunTest(unittest.TestCase):
         }
         diagnostic_parameter_path = os.path.join(MODULE_DIR, "procedure_templates")
         project_name = "PreDiag"
-        v_range = get_diagnostic_parameters(
+        v_range = parameters_lookup.get_diagnostic_parameters(
             diagnostic_available, diagnostic_parameter_path, project_name
         )
         self.assertEqual(v_range, [2.7, 4.2])

--- a/beep/utils/__init__.py
+++ b/beep/utils/__init__.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 from collections import OrderedDict
 from .workflow import Logger, WorkflowOutputs
+from .parameters_lookup import get_protocol_parameters, get_project_sequence, get_diagnostic_parameters
 from .splice import MaccorSplice
 from pydash import get, set_with, unset, merge
 

--- a/beep/utils/parameters_lookup.py
+++ b/beep/utils/parameters_lookup.py
@@ -1,0 +1,102 @@
+"""
+Module for finding parameters for projects
+"""
+import pandas as pd
+from glob import glob
+import os
+from beep import logger
+
+s = {"service": "DataStructurer"}
+
+
+def get_project_sequence(path):
+    """
+    Returns project sequence for a given path
+
+    Args:
+        path (str): full project file path
+
+    Returns:
+        ([str]): list of project parts
+
+    """
+    root, file = os.path.split(path)
+    file = file.split(".")[0]
+    file_parts = file.split("_")
+    return file_parts
+
+
+def get_protocol_parameters(filepath, parameters_path="data-share/raw/parameters"):
+    """
+    Helper function to get the project parameters for a file given the filename
+
+    Args:
+        filepath (str): full path to the file
+        parameters_path (str): location to look for parameter files
+
+    Returns:
+        pandas.DataFrame: single row DataFrame corresponding to the parameters for this file
+        pandas.DataFrame: DataFrame with all of the parameter for the project
+
+    """
+    project_name_list = get_project_sequence(filepath)
+    project_name = project_name_list[0]
+    path = os.path.join(os.environ.get("BEEP_PROCESSING_DIR", "/"), parameters_path)
+    project_parameter_files = glob(os.path.join(path, project_name + "*"))
+    assert len(project_parameter_files) <= 1, (
+        "Found too many parameter files for: " + project_name
+    )
+
+    if len(project_parameter_files) == 1:
+        df = pd.read_csv(project_parameter_files[0])
+        parameter_row = df[df.seq_num == int(project_name_list[1])]
+        if parameter_row.empty:
+            logger.error("Unable to get project parameters for: %s", filepath, extra=s)
+            parameter_row = None
+            df = None
+    else:
+        parameter_row = None
+        df = None
+    return parameter_row, df
+
+
+def get_diagnostic_parameters(
+    diagnostic_available, diagnostic_parameter_path, project_name
+):
+    """
+    Interpolates data according to location and type of diagnostic
+    cycles in the data
+
+    Args:
+        diagnostic_available (dict): dictionary with diagnostic_types as list,
+            'length' of the diagnostic in cycles and location of the diagnostic
+        diagnostic_parameter_path (str): full path to the location of the
+            diagnostic parameter files
+        project_name (str): name of the project to search with
+
+    Returns:
+        (list): containing upper and lower voltage limits for the
+            diagnostic cycle
+
+    """
+    project_diag_files = glob(
+        os.path.join(diagnostic_parameter_path, project_name + "*")
+    )
+    assert len(project_diag_files) <= 1, (
+        "Found too many diagnostic parameter files for: " + project_name
+    )
+
+    # Find the voltage range for the diagnostic cycles
+    if len(project_diag_files) == 1:
+        df = pd.read_csv(project_diag_files[0])
+        diag_row = df[
+            df.diagnostic_parameter_set == diagnostic_available["parameter_set"]
+        ]
+        v_range = [
+            diag_row["diagnostic_discharge_cutoff_voltage"].iloc[0],
+            diag_row["diagnostic_charge_cutoff_voltage"].iloc[0],
+        ]
+    else:
+        v_range = [2.7, 4.2]
+
+    return v_range


### PR DESCRIPTION
This PR fixes a bug so that the summary attribute no longer includes the diagnostic cycles. It also changes the throughput calculation to separate throughput due to regular and diagnostic cycles.
- Adds the argument to pass the diagnostic_available to the `get_summary` function
- Adds assert statements to a test to ensure that summary no longer contains the diagnostic cycles
- Changes the throughput calculation
- Removes initialization cycle from the throughput calculation
- Adds diagnostic interval information