### PR TITLE
Add parsing and NaN handling for `get_fractional_quantity_remaining_nx`

### DIFF
--- a/beep/features/featurizer_helpers.py
+++ b/beep/features/featurizer_helpers.py
@@ -15,6 +15,7 @@ from lmfit import models
 from scipy.interpolate import interp1d
 from scipy.optimize import curve_fit
 from beep.utils import parameters_lookup
+import os
 
 
 # TODO: document these params
@@ -972,19 +973,26 @@ def get_fractional_quantity_remaining_nx(
         regular_summary[regular_summary.cycle_index < x['cycle_index']][normalize_qty_throughput].max(),
         axis=1
     )
+    summary_diag_cycle_type['normalized_regular_throughput'].fillna(value=0, inplace=True)
     summary_diag_cycle_type['normalized_diagnostic_throughput'] = summary_diag_cycle_type.apply(
         lambda x: (1 / initial_regular_throughput) *
         diagnostic_summary[diagnostic_summary.cycle_index < x['cycle_index']][normalize_qty_throughput].max(),
         axis=1
     )
-
+    summary_diag_cycle_type['normalized_diagnostic_throughput'].fillna(value=0, inplace=True)
     # end of nx addition, calculate the fractional capacity compared to the first diagnostic cycle (reset)
     summary_diag_cycle_type[metric] = (
         summary_diag_cycle_type[metric]
         / processed_cycler_run.diagnostic_summary[metric].iloc[0]
     )
 
-    parameter_row, _ = parameters_lookup.get_protocol_parameters(processed_cycler_run.protocol)
+    if "\\" in processed_cycler_run.protocol:
+        protocol_name = processed_cycler_run.protocol.split("\\")[-1]
+    else:
+        _, protocol_name = os.path.split(processed_cycler_run.protocol)
+
+    parameter_row, _ = parameters_lookup.get_protocol_parameters(protocol_name)
+
     summary_diag_cycle_type['diagnostic_start_cycle'] = parameter_row['diagnostic_start_cycle'].values[0]
     summary_diag_cycle_type['diagnostic_interval'] = parameter_row['diagnostic_interval'].values[0]
     # TODO add number of initial regular cycles and interval to the dataframe

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -377,14 +377,14 @@ class TestFeaturizer(unittest.TestCase):
             )
 
     def test_get_fractional_quantity_remaining_nx(self):
-        processed_cycler_run_path = os.path.join(
+        processed_cycler_run_path_1 = os.path.join(
             TEST_FILE_DIR, "PreDiag_000233_00021F_truncated_structure.json"
         )
-        pcycler_run = loadfn(processed_cycler_run_path)
+        pcycler_run = loadfn(processed_cycler_run_path_1)
         pcycler_run.summary = pcycler_run.summary[~pcycler_run.summary.cycle_index.isin(pcycler_run.diagnostic_summary.cycle_index)]
-        # print(pcycler_run.summary.cycle_index)
+
         os.environ["BEEP_PROCESSING_DIR"] = TEST_FILE_DIR
-        # test_param_path = os.path.join(TEST_FILE_DIR, "data-share", "raw", "parameters")
+
         sum_diag = featurizer_helpers.get_fractional_quantity_remaining_nx(pcycler_run,
                                                                            metric="discharge_energy",
                                                                            diagnostic_cycle_type="hppc")
@@ -394,6 +394,7 @@ class TestFeaturizer(unittest.TestCase):
         self.assertEqual(np.around(sum_diag["initial_regular_throughput"].iloc[0], 3), np.around(237.001769, 3))
         self.assertEqual(np.around(sum_diag["normalized_regular_throughput"].iloc[15], 3), np.around(45.145, 3))
         self.assertEqual(np.around(sum_diag["normalized_diagnostic_throughput"].iloc[15], 3), np.around(5.098, 3))
+        self.assertFalse(sum_diag.isnull().values.any())
         self.assertEqual(sum_diag['diagnostic_start_cycle'].iloc[0], 30)
         self.assertEqual(sum_diag['diagnostic_interval'].iloc[0], 100)
 
@@ -407,6 +408,24 @@ class TestFeaturizer(unittest.TestCase):
         self.assertEqual(np.around(sum_diag["normalized_diagnostic_throughput"].iloc[15], 3), np.around(5.229, 3))
         self.assertEqual(sum_diag['diagnostic_start_cycle'].iloc[0], 30)
         self.assertEqual(sum_diag['diagnostic_interval'].iloc[0], 100)
+
+        processed_cycler_run_path_2 = os.path.join(
+            TEST_FILE_DIR, "Talos_001383_NCR18650618001_CH31_truncated_structure.json"
+        )
+        pcycler_run = loadfn(processed_cycler_run_path_2)
+
+        os.environ["BEEP_PROCESSING_DIR"] = TEST_FILE_DIR
+
+        sum_diag = featurizer_helpers.get_fractional_quantity_remaining_nx(pcycler_run,
+                                                                           metric="discharge_energy",
+                                                                           diagnostic_cycle_type="hppc")
+        self.assertEqual(len(sum_diag.index), 3)
+        self.assertEqual(sum_diag.cycle_index.max(), 242)
+        self.assertEqual(np.around(sum_diag["initial_regular_throughput"].iloc[0], 3), np.around(331.428, 3))
+        self.assertEqual(np.around(sum_diag["normalized_regular_throughput"].iloc[2], 3), np.around(6.817, 3))
+        self.assertEqual(np.around(sum_diag["normalized_diagnostic_throughput"].iloc[2], 3), np.around(0.385, 3))
+        self.assertEqual(sum_diag['diagnostic_start_cycle'].iloc[0], 30)
+        self.assertEqual(sum_diag['diagnostic_interval'].iloc[0], 200)
 
     def test_generate_dQdV_peak_fits(self):
         processed_cycler_run_path = os.path.join(


### PR DESCRIPTION
This PR adds parsing for runs where the protocol field has a normed path instead of just a file name. It also imputes `0` for `NaN` values in the throughput since these are occurring where there are no cycles to accumulate
- Add parsing to the protocol name extraction
- Impute `0` for throughput with `NaN` values