### PR TITLE
add seq_num to dataset.data attribute, and expose parameters_path in datasets and features

### DIFF
--- a/beep/dataset.py
+++ b/beep/dataset.py
@@ -161,6 +161,9 @@ class BeepDataset(MSONable):
                         obj = loadfn(feature_json)
                         df = obj.X
                         df['file'] = obj.metadata['protocol'].split('.')[0]
+                        # seq_num computation assumes file naming follows the convention:
+                        # ProjectName_SeqNum_Channel_ObjectName.json
+                        df['seq_num'] = int(os.path.basename(feature_json).split('_')[1])
                         feature_df = pd.concat([feature_df, df]).reset_index(drop=True)
                         # TODO: Need some logic for ensuring that features of a given class being concatenated
                         # row-wise have the same metadata dict
@@ -172,7 +175,7 @@ class BeepDataset(MSONable):
                 missing.loc[len(missing)] = \
                     ['', feature_class.class_feature_name]
 
-        df = reduce(lambda x, y: pd.merge(x, y, on='file', how='outer'), feature_df_list)
+        df = reduce(lambda x, y: pd.merge(x, y, on=['file', 'seq_num'], how='outer'), feature_df_list)
         # Outer-join used so that even partially featurized cells can be loaded into dataset
         # NaNs imputation to be done downstream by the user
 
@@ -254,6 +257,7 @@ class BeepDataset(MSONable):
                     if obj:
                         df = obj.X
                         df['file'] = obj.metadata['protocol'].split('.')[0]
+                        df['seq_num'] = int(os.path.basename(processed_json).split('_')[1])
                         feature_df_list[idx] = pd.concat([feature_df_list[idx], df]).reset_index(drop=True)
                     else:
                         failed_featurizations.loc[len(failed_featurizations)] = \
@@ -263,7 +267,7 @@ class BeepDataset(MSONable):
         for idx, feature_class in enumerate(feature_class_list):
             feature_sets[feature_class.class_feature_name] = list(feature_df_list[idx].columns)
 
-        df = reduce(lambda x, y: pd.merge(x, y, on='file', how='outer'), feature_df_list)
+        df = reduce(lambda x, y: pd.merge(x, y, on=['file', 'seq_num'], how='outer'), feature_df_list)
         return cls(name, df, hyperparameter_dict, df.file.unique(), feature_sets, dataset_dir, failed_featurizations)
 
     def generate_train_test_split(self, predictors=None, outcomes=None,

--- a/beep/dataset.py
+++ b/beep/dataset.py
@@ -186,7 +186,8 @@ class BeepDataset(MSONable):
                                    feature_class_list=FEATURIZER_CLASSES,
                                    hyperparameter_dict=None, processed_dir="data-share/structure/",
                                    feature_dir="data-share/features/",
-                                   dataset_dir="data-share/datasets"):
+                                   dataset_dir="data-share/datasets",
+                                   parameters_path="data-share/raw/parameters"):
         """
         Method to assemble a dataset directly from a list of ProcessedCyclerRun objects
 
@@ -253,7 +254,8 @@ class BeepDataset(MSONable):
             for feature_class in feature_class_list:
                 # For a given feature_class, loop through multiple hyperparameter combinations, if provided.
                 for d in hyperparameter_dict[feature_class.class_feature_name]:
-                    obj = feature_class.from_run(processed_json, feature_dir, processed_cycler_run, d)
+                    obj = feature_class.from_run(processed_json, feature_dir, processed_cycler_run,
+                                                 d, parameters_path=parameters_path)
                     if obj:
                         df = obj.X
                         df['file'] = obj.metadata['protocol'].split('.')[0]

--- a/beep/features/featurizer_helpers.py
+++ b/beep/features/featurizer_helpers.py
@@ -911,7 +911,8 @@ def get_fractional_quantity_remaining(
 def get_fractional_quantity_remaining_nx(
         processed_cycler_run,
         metric="discharge_energy",
-        diagnostic_cycle_type="rpt_0.2C"
+        diagnostic_cycle_type="rpt_0.2C",
+        parameters_path="data-share/raw/parameters"
 ):
     """
     Similar to get_fractional_quantity_remaining()
@@ -991,7 +992,7 @@ def get_fractional_quantity_remaining_nx(
     else:
         _, protocol_name = os.path.split(processed_cycler_run.protocol)
 
-    parameter_row, _ = parameters_lookup.get_protocol_parameters(protocol_name)
+    parameter_row, _ = parameters_lookup.get_protocol_parameters(protocol_name, parameters_path=parameters_path)
 
     summary_diag_cycle_type['diagnostic_start_cycle'] = parameter_row['diagnostic_start_cycle'].values[0]
     summary_diag_cycle_type['diagnostic_interval'] = parameter_row['diagnostic_interval'].values[0]

--- a/beep/featurize.py
+++ b/beep/featurize.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Module and scripts for generating descriptors (quantities listed
-in cell_analysis.m) from cycle-level summary statistics.
+Module and scripts for generating feature objects from structured
+battery cycling data, to be used as inputs for machine learning
+early prediction models.
 
 Usage:
     featurize [INPUT_JSON]

--- a/beep/featurize.py
+++ b/beep/featurize.py
@@ -98,7 +98,8 @@ class BeepFeatures(MSONable, metaclass=ABCMeta):
 
     @classmethod
     def from_run(
-        cls, input_filename, feature_dir, processed_cycler_run, params_dict=None
+        cls, input_filename, feature_dir, processed_cycler_run,
+            params_dict=None, parameters_path="data-share/raw/parameters"
     ):
         """
         This method contains the workflow for the creation of the feature class
@@ -112,6 +113,8 @@ class BeepFeatures(MSONable, metaclass=ABCMeta):
             processed_cycler_run (beep.structure.ProcessedCyclerRun): data from cycler run
             params_dict (dict): dictionary of parameters governing how the ProcessedCyclerRun object
             gets featurized. These could be filters for column or row operations
+            parameters_path (str): Root directory storing project parameter files.
+
         Returns:
             (beep.featurize.BeepFeatures): class object for the feature set
         """
@@ -121,7 +124,7 @@ class BeepFeatures(MSONable, metaclass=ABCMeta):
                 input_filename, feature_dir
             )
             feature_object = cls.features_from_processed_cycler_run(
-                processed_cycler_run, params_dict
+                processed_cycler_run, params_dict, parameters_path=parameters_path
             )
             metadata = cls.metadata_from_processed_cycler_run(
                 processed_cycler_run, params_dict
@@ -175,7 +178,8 @@ class BeepFeatures(MSONable, metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    def features_from_processed_cycler_run(cls, processed_cycler_run, params_dict=None):
+    def features_from_processed_cycler_run(cls, processed_cycler_run, params_dict=None,
+                                           parameters_path="data-share/raw/parameters"):
         raise NotImplementedError
 
     @classmethod
@@ -272,12 +276,15 @@ class RPTdQdVFeatures(BeepFeatures):
         return all(conditions)
 
     @classmethod
-    def features_from_processed_cycler_run(cls, processed_cycler_run, params_dict=None):
+    def features_from_processed_cycler_run(cls, processed_cycler_run, params_dict=None,
+                                           parameters_path="data-share/raw/parameters"):
         """
         Args:
             processed_cycler_run (beep.structure.ProcessedCyclerRun)
             params_dict (dict): dictionary of parameters governing how the ProcessedCyclerRun object
                 gets featurized. These could be filters for column or row operations
+            parameters_path (str): Root directory storing project parameter files.
+
 
         Returns:
              (pd.DataFrame) containing features based on gaussian fits to dQdV features in rpt cycles
@@ -397,7 +404,8 @@ class HPPCResistanceVoltageFeatures(BeepFeatures):
         return all(conditions)
 
     @classmethod
-    def features_from_processed_cycler_run(cls, processed_cycler_run, params_dict=None):
+    def features_from_processed_cycler_run(cls, processed_cycler_run, params_dict=None,
+                                           parameters_path="data-share/raw/parameters"):
         """
         This method calculates features based on voltage, diffusion and resistance changes in hppc cycles.
 
@@ -413,6 +421,8 @@ class HPPCResistanceVoltageFeatures(BeepFeatures):
             processed_cycler_run (beep.structure.ProcessedCyclerRun)
             params_dict (dict): dictionary of parameters governing how the ProcessedCyclerRun object
             gets featurized. These could be filters for column or row operations
+            parameters_path (str): Root directory storing project parameter files.
+
 
         Returns:
             dataframe of features based on voltage and resistance changes over a SOC window in hppc cycles
@@ -547,7 +557,8 @@ class HPPCRelaxationFeatures(BeepFeatures):
         return all(conditions)
 
     @classmethod
-    def features_from_processed_cycler_run(cls, processed_cycler_run, params_dict=None):
+    def features_from_processed_cycler_run(cls, processed_cycler_run, params_dict=None,
+                                           parameters_path="data-share/raw/parameters"):
         """
         This function returns all of the relaxation features in a dataframe for a given processed cycler run.
 
@@ -556,6 +567,7 @@ class HPPCRelaxationFeatures(BeepFeatures):
             you want the diagnostic features for.
             params_dict (dict): dictionary of parameters governing how the ProcessedCyclerRun object
             gets featurized. These could be filters for column or row operations
+            parameters_path (str): Root directory storing project parameter files.
 
         Returns:
             @featureDf(pd.DataFrame): Columns are either SOC{#%}_degrad{#%} where the first #% is the
@@ -643,7 +655,8 @@ class DiagnosticSummaryStats(BeepFeatures):
         return all(conditions)
 
     @classmethod
-    def features_from_processed_cycler_run(cls, processed_cycler_run, params_dict=None):
+    def features_from_processed_cycler_run(cls, processed_cycler_run, params_dict=None,
+                                           parameters_path="data-share/raw/parameters"):
         """
         Generate features listed in early prediction manuscript using both diagnostic and regular cycles
 
@@ -651,6 +664,8 @@ class DiagnosticSummaryStats(BeepFeatures):
             processed_cycler_run (beep.structure.ProcessedCyclerRun)
             params_dict (dict): dictionary of parameters governing how the ProcessedCyclerRun object
             gets featurized. These could be filters for column or row operations
+            parameters_path (str): Root directory storing project parameter files.
+
         Returns:
             X (pd.DataFrame): Dataframe containing the feature
         """
@@ -852,7 +867,8 @@ class DeltaQFastCharge(BeepFeatures):
         return all(conditions)
 
     @classmethod
-    def features_from_processed_cycler_run(cls, processed_cycler_run, params_dict=None):
+    def features_from_processed_cycler_run(cls, processed_cycler_run, params_dict=None,
+                                           parameters_path="data-share/raw/parameters"):
         """
         Generate features listed in early prediction manuscript, primarily related to the
         so called delta Q feature
@@ -860,6 +876,8 @@ class DeltaQFastCharge(BeepFeatures):
             processed_cycler_run (beep.structure.ProcessedCyclerRun): data from cycler run
             params_dict (dict): dictionary of parameters governing how the ProcessedCyclerRun object
                 gets featurized. These could be filters for column or row operations
+            parameters_path (str): Root directory storing project parameter files.
+
         Returns:
             pd.DataFrame: features indicative of degradation, derived from the input data
         """
@@ -1045,7 +1063,8 @@ class TrajectoryFastCharge(DeltaQFastCharge):
         return all(conditions)
 
     @classmethod
-    def features_from_processed_cycler_run(cls, processed_cycler_run, params_dict=None):
+    def features_from_processed_cycler_run(cls, processed_cycler_run, params_dict=None,
+                                           parameters_path="data-share/raw/parameters"):
         """
         Calculate the outcomes from the input data. In particular, the number of cycles
         where we expect to reach certain thresholds of capacity loss
@@ -1053,6 +1072,8 @@ class TrajectoryFastCharge(DeltaQFastCharge):
             processed_cycler_run (beep.structure.ProcessedCyclerRun): data from cycler run
             params_dict (dict): dictionary of parameters governing how the ProcessedCyclerRun object
             gets featurized. These could be filters for column or row operations
+            parameters_path (str): Root directory storing project parameter files.
+
         Returns:
             pd.DataFrame: cycles at which capacity/energy degradation exceeds thresholds
         """
@@ -1110,13 +1131,16 @@ class DiagnosticProperties(BeepFeatures):
             return True
 
     @classmethod
-    def features_from_processed_cycler_run(cls, processed_cycler_run, params_dict=None):
+    def features_from_processed_cycler_run(cls, processed_cycler_run, params_dict=None,
+                                           parameters_path="data-share/raw/parameters"):
         """
         Generates diagnostic-property features from processed cycler run, including values for n*x method
         Args:
             processed_cycler_run (beep.structure.ProcessedCyclerRun): data from cycler run
             params_dict (dict): dictionary of parameters governing how the ProcessedCyclerRun object
             gets featurized. These could be filters for column or row operations
+            parameters_path (str): Root directory storing project parameter files.
+
         Returns:
             pd.DataFrame: with "cycle_index", "fractional_metric", "x", "n", "cycle_type" and "metric" columns, rows
             for each diagnostic cycle of the cell
@@ -1129,7 +1153,7 @@ class DiagnosticProperties(BeepFeatures):
         for quantity in params_dict["quantities"]:
             for cycle_type in cycle_types:
                 summary_diag_cycle_type = featurizer_helpers.get_fractional_quantity_remaining_nx(
-                    processed_cycler_run, quantity, cycle_type
+                    processed_cycler_run, quantity, cycle_type, parameters_path=parameters_path
                 )
 
                 summary_diag_cycle_type["cycle_type"] = cycle_type

--- a/beep/tests/test_dataset.py
+++ b/beep/tests/test_dataset.py
@@ -43,7 +43,9 @@ class TestDataset(unittest.TestCase):
         dataset = BeepDataset.from_features('test_dataset', ['PreDiag'], FEATURIZER_CLASSES,
                                             feature_dir=os.path.join(TEST_FILE_DIR, 'data-share/features'))
         self.assertEqual(dataset.name, 'test_dataset')
-        self.assertEqual(dataset.data.shape, (2, 55))
+        self.assertEqual(dataset.data.shape, (2, 56))
+        #from pdb import set_trace; set_trace()
+        self.assertListEqual(list(dataset.data.seq_num), [196, 197])
         self.assertIsNone(dataset.X_test)
         self.assertSetEqual(set(dataset.feature_sets.keys()), {'RPTdQdVFeatures', 'DiagnosticSummaryStats'})
         self.assertEqual(dataset.missing.feature_class.iloc[0], 'HPPCResistanceVoltageFeatures')
@@ -59,7 +61,8 @@ class TestDataset(unittest.TestCase):
                                                              processed_dir=TEST_FILE_DIR,
                                                              feature_dir='data-share/features')
             self.assertEqual(dataset.name, 'test_dataset')
-            self.assertEqual(dataset.data.shape, (1, 118))
+            self.assertEqual(dataset.data.shape, (1, 119))
+            self.assertEqual(dataset.data.seq_num.iloc[0], 240)
             self.assertIsNone(dataset.X_test)
 
             self.assertEqual(dataset.missing.shape, (3, 2))
@@ -81,7 +84,7 @@ class TestDataset(unittest.TestCase):
                                                                            'raw',
                                                                            'parameters'))
 
-        self.assertEqual(dataset.data.shape, (2, 55))
+        self.assertEqual(dataset.data.shape, (2, 56))
         self.assertEqual(dataset.X_test.shape, (1, 6))
         self.assertEqual(dataset.X_train.shape, (1, 6))
 


### PR DESCRIPTION
- PR to add `seq_num` as one of the fields in `BeepDataset.data`.
- When multiple feature-sets are merged, JOIN is performed on both `file` and `seq_num`. This allows runs with potentially same `seq_num` from different projects to be assembled in the same dataset.
- Also handles MAT-2141: exposes `parameters_path` in methods occurring in featurizer_helpers, featurize and dataset modules
