### PR TITLE
serialization and custom hyperparam tests for datasets

### DIFF
--- a/beep/dataset.py
+++ b/beep/dataset.py
@@ -75,7 +75,7 @@ class BeepDataset(MSONable):
 
     """
 
-    def __init__(self, name, data, metadata, filenames, feature_sets, dataset_dir, missing=None):
+    def __init__(self, name, data, metadata, filenames, feature_sets, dataset_dir='data-share/datasets', missing=None):
 
         """
         Invokes BeepDataset object
@@ -118,7 +118,9 @@ class BeepDataset(MSONable):
             "data": self.data.to_dict("list"),
             "metadata": self.metadata,
             "filenames": self.filenames,
-            "feature_sets": self.feature_sets
+            "dataset_dir": self.dataset_dir,
+            "feature_sets": self.feature_sets,
+            "missing": self.missing.to_dict("list")
         }
         return obj
 
@@ -126,6 +128,7 @@ class BeepDataset(MSONable):
     def from_dict(cls, d):
         """MSONable deserialization method"""
         d["data"] = pd.DataFrame(d["data"])
+        d["missing"] = pd.DataFrame(d["missing"])
         return cls(**d)
 
     @classmethod

--- a/beep/dataset.py
+++ b/beep/dataset.py
@@ -129,6 +129,7 @@ class BeepDataset(MSONable):
         """MSONable deserialization method"""
         d["data"] = pd.DataFrame(d["data"])
         d["missing"] = pd.DataFrame(d["missing"])
+        d["filenames"] = list(d["filenames"])
         return cls(**d)
 
     @classmethod

--- a/beep/features/featurizer_helpers.py
+++ b/beep/features/featurizer_helpers.py
@@ -210,7 +210,7 @@ def generate_dQdV_peak_fits(
 
     Args:
         processed_cycler_run: processed_cycler_run (beep.structure.ProcessedCyclerRun)
-        diag_nr: if 1, takes dQdV of 1st RPT past the initial diagnostic, 0 (default) is initial dianostic
+        diag_nr: if 1, takes dQdV of 1st RPT past the initial diagnostic, 0 (default) is initial diagnostic
         charge_y_n: if 1 (default), takes charge dQdV, if 0, takes discharge dQdV
 
     Returns:

--- a/beep/tests/test_dataset.py
+++ b/beep/tests/test_dataset.py
@@ -106,7 +106,7 @@ class TestDataset(unittest.TestCase):
                                                              hyperparameter_dict=hyperparameter_dict,
                                                              feature_dir='data-share/features')
             self.assertEqual(dataset.name, 'test_dataset')
-            self.assertEqual(dataset.data.shape, (1, 141))
+            self.assertEqual(dataset.data.shape, (1, 135))
             self.assertEqual(dataset.data.seq_num.iloc[0], 240)
             self.assertIsNone(dataset.X_test)
 

--- a/beep/tests/test_dataset.py
+++ b/beep/tests/test_dataset.py
@@ -90,9 +90,9 @@ class TestDataset(unittest.TestCase):
         with ScratchDir("."):
             os.environ["BEEP_PROCESSING_DIR"] = os.getcwd()
             hyperparameter_dict = {'RPTdQdVFeatures': [
-                {'diag_ref': 0, 'diag_nr': 1, 'charge_y_n': 1, 'rpt_type': 'rpt_0.2C', 'plotting_y_n': 0},
-                {'diag_ref': 0, 'diag_nr': 1, 'charge_y_n': 1, 'rpt_type': 'rpt_1C', 'plotting_y_n': 0},
-                {'diag_ref': 0, 'diag_nr': 1, 'charge_y_n': 1, 'rpt_type': 'rpt_2C', 'plotting_y_n': 0}],
+                {'diag_ref': 0, 'diag_nr': 1, 'charge_y_n': 0, 'rpt_type': 'rpt_0.2C', 'plotting_y_n': 0},
+                {'diag_ref': 0, 'diag_nr': 1, 'charge_y_n': 0, 'rpt_type': 'rpt_1C', 'plotting_y_n': 0},
+                {'diag_ref': 0, 'diag_nr': 1, 'charge_y_n': 0, 'rpt_type': 'rpt_2C', 'plotting_y_n': 0}],
                                    'HPPCResistanceVoltageFeatures': [
                                        FEATURE_HYPERPARAMS['HPPCResistanceVoltageFeatures']],
                                    'DiagnosticSummaryStats': [FEATURE_HYPERPARAMS['DiagnosticSummaryStats']]

--- a/beep/tests/test_dataset.py
+++ b/beep/tests/test_dataset.py
@@ -65,6 +65,7 @@ class TestDataset(unittest.TestCase):
             self.assertIsNone(dataset.X_test)
             self.assertSetEqual(set(dataset.feature_sets.keys()), {'RPTdQdVFeatures', 'DiagnosticSummaryStats'})
             self.assertEqual(dataset.missing.feature_class.iloc[0], 'HPPCResistanceVoltageFeatures')
+            self.assertIsInstance(dataset.filenames, list)
 
 
     def test_from_processed_cycler_run_list(self):


### PR DESCRIPTION
PR to add 
- tests for serialization/deserialization of BeepDataset class
- tests for dataset generation from processed_cycler_run objects with custom hyperparam sets. For instance, RPTdQdVFeatures can be generated for the different rpt cycles in the same dataset.