### PR TITLE
Change the validation voltage limits

### DIFF
--- a/beep/validation_schemas/schema-arbin-18650-2170.yaml
+++ b/beep/validation_schemas/schema-arbin-18650-2170.yaml
@@ -28,7 +28,7 @@ test_time:
   type: list
 voltage:
   schema:
-    max: 4.5
+    max: 5.0
     min: 2.0
     type: float
   type: list

--- a/beep/validation_schemas/schema-arbin-nmc-phev.yaml
+++ b/beep/validation_schemas/schema-arbin-nmc-phev.yaml
@@ -28,7 +28,7 @@ test_time:
   type: list
 voltage:
   schema:
-    max: 4.3
+    max: 5.0
     min: 0.0
     type: float
   type: list

--- a/beep/validation_schemas/schema-maccor-2170.yaml
+++ b/beep/validation_schemas/schema-maccor-2170.yaml
@@ -16,8 +16,8 @@ state:
   type: list
 volts:
   schema:
-    max: 4.45
-    min: 1.2
+    max: 5.0
+    min: 0
     type: float
   type: list
 amps:


### PR DESCRIPTION
This PR changes the voltage limits for validation to allow processing of files where the cell has been disconnected at the end of the test so the voltage floats.
- Change upper limit to 5V
- Change lower limit to 0V

Tested with "xIris_000002_0000B2_CH3.csv" and "PreDiag_000298_000159.008" to make sure structuring succeeds and these files are now marked as valid.