### PR TITLE
Fix negative paused values

### DIFF
--- a/beep/conversion_schemas/structured_dtypes.yaml
+++ b/beep/conversion_schemas/structured_dtypes.yaml
@@ -25,7 +25,7 @@ summary:
   energy_throughput: 'float32'
   charge_duration: 'float32'
   time_temperature_integrated: 'float64'
-  paused: 'int8'
+  paused: 'int32'
 
 diagnostic_summary:
   discharge_capacity: 'float64'
@@ -38,7 +38,7 @@ diagnostic_summary:
   date_time_iso: 'object'
   cycle_index: 'int32'
   coulombic_efficiency: 'float64'
-  paused: 'int8'
+  paused: 'int32'
   cycle_type: 'category'
 
 diagnostic_interpolated:

--- a/beep/structure.py
+++ b/beep/structure.py
@@ -563,13 +563,14 @@ class RawCyclerRun(MSONable):
             "date_time_iso",
             "cycle_index",
         ]
+        diag_summary["paused"] = self.data.groupby("cycle_index").apply(
+            get_max_paused_over_threshold
+        )
+
         diag_summary = diag_summary[diag_summary.index.isin(diag_cycles_at)]
 
         diag_summary["coulombic_efficiency"] = (
             diag_summary["discharge_capacity"] / diag_summary["charge_capacity"]
-        )
-        diag_summary["paused"] = self.data.groupby("cycle_index").apply(
-            get_max_paused_over_threshold
         )
 
         diag_summary.reset_index(drop=True, inplace=True)


### PR DESCRIPTION
Change the datatype for `paused` summary attribute to be `int32`.  Since `paused` evaluates max pause duration in seconds, `int8` type was leading to negative values anytime 127 was exceeded.