### PR TITLE
Mat 2195 add energy to interpolated cycles and fix bad data

### DIFF
--- a/beep/conversion_schemas/structured_dtypes.yaml
+++ b/beep/conversion_schemas/structured_dtypes.yaml
@@ -5,8 +5,10 @@ cycles_interpolated:
   voltage: 'float32'
   temperature: 'float32'
   internal_resistance: 'float32'
-  charge_capacity: 'float64'
-  discharge_capacity: 'float64'
+  charge_capacity: 'float32'
+  discharge_capacity: 'float32'
+  charge_energy: 'float32'
+  discharge_energy: 'float32'
   step_type: 'category'
 
 summary:
@@ -20,7 +22,7 @@ summary:
   temperature_average: 'float32'
   temperature_minimum: 'float32'
   date_time_iso: 'object'
-  energy_efficiency: 'float64'
+  energy_efficiency: 'float32'
   charge_throughput: 'float32'
   energy_throughput: 'float32'
   charge_duration: 'float32'
@@ -51,14 +53,13 @@ diagnostic_interpolated:
   internal_resistance: 'float32'
   temperature: 'float32'
   test_time: 'float64'
-  date_time_iso: 'object'
   cycle_index: 'int32'
   cycle_type: 'category'
   step_index: 'int16'
   step_index_counter: 'int16'
   step_type: 'category'
-  discharge_dQdV: 'float64'
-  charge_dQdV: 'float64'
+  discharge_dQdV: 'float32'
+  charge_dQdV: 'float32'
 
 
 

--- a/beep/structure.py
+++ b/beep/structure.py
@@ -217,6 +217,8 @@ class RawCyclerRun(MSONable):
             "current",
             "charge_capacity",
             "discharge_capacity",
+            "charge_energy",
+            "discharge_energy",
             "internal_resistance",
             "temperature",
         ]
@@ -630,13 +632,13 @@ class RawCyclerRun(MSONable):
         diag_data = self.data[self.data["cycle_index"].isin(diag_cycles_at)]
 
         # Convert date_time_iso field into pd.datetime object
-        diag_data.loc[:, "date_time_iso"] = pd.to_datetime(diag_data["date_time_iso"])
+        # diag_data.loc[:, "date_time_iso"] = pd.to_datetime(diag_data["date_time_iso"])
 
         # Convert datetime into seconds to allow interpolation of time
-        diag_data.loc[:, "datetime_seconds"] = [
-            time.mktime(t.timetuple()) if t is not pd.NaT else float("nan")
-            for t in diag_data["date_time_iso"]
-        ]
+        # diag_data.loc[:, "datetime_seconds"] = [
+        #     time.mktime(t.timetuple()) if t is not pd.NaT else float("nan")
+        #     for t in diag_data["date_time_iso"]
+        # ]
 
         # Counter to ensure non-contiguous repeats of step_index
         # within same cycle_index are grouped separately
@@ -658,7 +660,6 @@ class RawCyclerRun(MSONable):
             "discharge_energy",
             "internal_resistance",
             "temperature",
-            "datetime_seconds",
             "test_time",
         ]
 
@@ -692,13 +693,6 @@ class RawCyclerRun(MSONable):
                     columns=incl_columns,
                     resolution=resolution,
                 )
-
-            # Convert interpolated time in seconds back to datetime
-            new_df["date_time_iso"] = [
-                datetime.utcfromtimestamp(t).isoformat() if ~np.isnan(t) else t
-                for t in new_df["datetime_seconds"]
-            ]
-            new_df = new_df.drop(columns="datetime_seconds")
 
             new_df["cycle_index"] = cycle_index
             new_df["cycle_type"] = diag_cycle_type[diag_cycles_at.index(cycle_index)]
@@ -1926,7 +1920,7 @@ def get_interpolated_data(
     columns = columns or dataframe.columns
     columns = list(set(columns) | {field_name})
 
-    df = dataframe.loc[:, columns]
+    df = dataframe.reindex(columns=columns)
     field_range = field_range or [df[field_name].iloc[0], df[field_name].iloc[-1]]
     # If interpolating on datetime, change column to datetime series and
     # use date_range to create interpolating vector

--- a/beep/structure.py
+++ b/beep/structure.py
@@ -638,15 +638,6 @@ class RawCyclerRun(MSONable):
 
         diag_data = self.data[self.data["cycle_index"].isin(diag_cycles_at)]
 
-        # Convert date_time_iso field into pd.datetime object
-        # diag_data.loc[:, "date_time_iso"] = pd.to_datetime(diag_data["date_time_iso"])
-
-        # Convert datetime into seconds to allow interpolation of time
-        # diag_data.loc[:, "datetime_seconds"] = [
-        #     time.mktime(t.timetuple()) if t is not pd.NaT else float("nan")
-        #     for t in diag_data["date_time_iso"]
-        # ]
-
         # Counter to ensure non-contiguous repeats of step_index
         # within same cycle_index are grouped separately
         diag_data.loc[:, "step_index_counter"] = 0

--- a/beep/structure.py
+++ b/beep/structure.py
@@ -380,6 +380,7 @@ class RawCyclerRun(MSONable):
         cycle_complete_discharge_ratio=0.97,
         cycle_complete_vmin=3.3,
         cycle_complete_vmax=3.3,
+        error_threshold=1e6,
     ):
         """
         Gets summary statistics for data according to cycle number. Summary data
@@ -395,6 +396,9 @@ class RawCyclerRun(MSONable):
                 in any complete cycle
             cycle_complete_vmax (float): expected voltage maximum achieved
                 in any complete cycle
+            error_threshold (float): threshold to consider the summary value
+                an error (applied only to specific columns that should reset
+                each cycle)
 
         Returns:
             pandas.DataFrame: summary statistics by cycle.
@@ -449,6 +453,9 @@ class RawCyclerRun(MSONable):
         summary.loc[
             ~np.isfinite(summary["energy_efficiency"]), "energy_efficiency"
         ] = np.NaN
+        # This code is designed to remove erroneous energy values
+        for col in ["discharge_energy", "charge_energy"]:
+            summary.loc[summary[col].abs() > error_threshold, col] = np.NaN
         summary["charge_throughput"] = summary.charge_capacity.cumsum()
         summary["energy_throughput"] = summary.charge_energy.cumsum()
 

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -482,11 +482,11 @@ class TestFeaturizer(unittest.TestCase):
                  1.84972885518774, 1.5023615714170622]
             computed = featurizer.X.iloc[0].tolist()
             for indx, value in enumerate(x):
-                precision = 6
-                self.assertEqual(np.round(value, precision), np.round(computed[indx], precision))
+                precision = 5
+                self.assertEqual(np.around(np.float32(value), precision), np.around(np.float32(computed[indx]), precision))
 
-            self.assertEqual(np.round(featurizer.X['var_discharging_capacity'].iloc[0], 3),
-                             np.round(-3.771727344982484, 3))
+            self.assertEqual(np.around(featurizer.X['var_discharging_capacity'].iloc[0], 6),
+                             np.around(-3.771727344982484, 6))
 
     def test_DiagnosticProperties_class(self):
         with ScratchDir("."):


### PR DESCRIPTION
This PR addresses problems around the charge and discharge energy in the structured data.
- Adds charge and discharge energy to the regular interpolated cycles
- Removes values from the regular summary resulting from errors in the raw data