### PR TITLE
MAT-2304: Add Additional Statistics To get_hppc_ocv

### DIFF
--- a/beep/features/featurizer_helpers.py
+++ b/beep/features/featurizer_helpers.py
@@ -350,14 +350,16 @@ def get_hppc_ocv_helper(cycle_hppc_0, step_num):
 
 def get_hppc_ocv(processed_cycler_run, diag_pos):
     """
-    This function calculates the variance, min, mean, skew, kurtosis, sum and sum of squares of ocv changes between hppc cycle specified by and the first one.
+    This function calculates the variance, min, mean, skew, kurtosis, sum and sum of squares 
+    of ocv changes between hppc cycle specified by and the first one.
 
     Argument:
             processed_cycler_run (beep.structure.ProcessedCyclerRun)
             diag_pos (int): diagnostic cycle occurence for a specific <diagnostic_cycle_type>. e.g.
             if rpt_0.2C, occurs at cycle_index = [2, 37, 142, 244 ...], <diag_pos>=0 would correspond to cycle_index 2.
     Returns:
-            a dataframe with seven entries ('var_ocv, min_ocv, mean_ocv, skew_ocv, kurtosis_ocv, sum_ocv, sum_square_ocv'):
+            a dataframe with seven entries 
+            ('var_ocv, min_ocv, mean_ocv, skew_ocv, kurtosis_ocv, sum_ocv, sum_square_ocv'):
     """
 
     hppc_ocv_features = pd.DataFrame()

--- a/beep/features/featurizer_helpers.py
+++ b/beep/features/featurizer_helpers.py
@@ -681,13 +681,13 @@ def get_v_diff(processed_cycler_run, diag_pos, soc_window):
         print("weird voltage")
         return None
     else:
-        result["var(v_diff)"] = [np.var(v_diff)] 
-        result["min(v_diff)"] = [min(v_diff)]
-        result["mean(v_diff)"] = [np.mean(v_diff)]
-        result["skew(v_diff)"] = [skew(v_diff)]
-        result["kurtosis(v_diff)"] = [kurtosis(v_diff, fisher=False, bias=False)]
-        result["sum(v_diff)"] = [np.sum(np.absolute(v_diff))]
-        result["sum_square(v_diff)"] = [np.sum(np.square(v_diff))]
+        result["var_v_diff"] = [np.var(v_diff)] 
+        result["min_v_diff"] = [min(v_diff)]
+        result["mean_v_diff"] = [np.mean(v_diff)]
+        result["skew_v_diff"] = [skew(v_diff)]
+        result["kurtosis_v_diff"] = [kurtosis(v_diff, fisher=False, bias=False)]
+        result["sum_v_diff"] = [np.sum(np.absolute(v_diff))]
+        result["sum_square_v_diff"] = [np.sum(np.square(v_diff))]
 
         return result
 

--- a/beep/features/featurizer_helpers.py
+++ b/beep/features/featurizer_helpers.py
@@ -350,15 +350,14 @@ def get_hppc_ocv_helper(cycle_hppc_0, step_num):
 
 def get_hppc_ocv(processed_cycler_run, diag_pos):
     """
-    This function calculates the variance of ocv changes between hppc cycle specified by and the first one.
+    This function calculates the variance, min, mean, skew, kurtosis, sum and sum of squares of ocv changes between hppc cycle specified by and the first one.
 
     Argument:
             processed_cycler_run (beep.structure.ProcessedCyclerRun)
             diag_pos (int): diagnostic cycle occurence for a specific <diagnostic_cycle_type>. e.g.
             if rpt_0.2C, occurs at cycle_index = [2, 37, 142, 244 ...], <diag_pos>=0 would correspond to cycle_index 2.
     Returns:
-            a dataframe with one entry('variance of ocv'):
-                the variance of the diag_num minus cycle 2 for OCV.
+            a dataframe with seven entries ('var_ocv, min_ocv, mean_ocv, skew_ocv, kurtosis_ocv, sum_ocv, sum_square_ocv'):
     """
 
     hppc_ocv_features = pd.DataFrame()
@@ -384,11 +383,15 @@ def get_hppc_ocv(processed_cycler_run, diag_pos):
     selected_diag_df = cycle_hppc.loc[cycle_hppc.cycle_index == cycles[diag_pos]]
     voltage_2 = get_hppc_ocv_helper(selected_diag_df, step_later)
 
-    dv = list_minus(voltage_1, voltage_2)
+    ocv = list_minus(voltage_1, voltage_2)
 
-    var_dv = np.var(dv)
-
-    hppc_ocv_features["variance of ocv"] = [var_dv]
+    hppc_ocv_features["var_ocv"] = [np.var(ocv)]
+    hppc_ocv_features["min_ocv"] = [min(ocv)]
+    hppc_ocv_features["mean_ocv"] = [np.mean(ocv)]
+    hppc_ocv_features["skew_ocv"] = [skew(ocv)]
+    hppc_ocv_features["kurtosis_ocv"] = [kurtosis(ocv, fisher=False, bias=False)]
+    hppc_ocv_features["sum_ocv"] = [np.sum(np.absolute(ocv))]
+    hppc_ocv_features["sum_square_ocv"] = [np.sum(np.square(ocv))]
 
     return hppc_ocv_features
 

--- a/beep/tests/test_dataset.py
+++ b/beep/tests/test_dataset.py
@@ -93,7 +93,7 @@ class TestDataset(unittest.TestCase):
                                                              processed_dir=TEST_FILE_DIR,
                                                              feature_dir='data-share/features')
             self.assertEqual(dataset.name, 'test_dataset')
-            self.assertEqual(dataset.data.shape, (1, 125))
+            self.assertEqual(dataset.data.shape, (1, 131))
             self.assertEqual(dataset.data.seq_num.iloc[0], 240)
             self.assertIsNone(dataset.X_test)
 
@@ -126,7 +126,7 @@ class TestDataset(unittest.TestCase):
                                                              hyperparameter_dict=hyperparameter_dict,
                                                              feature_dir='data-share/features')
             self.assertEqual(dataset.name, 'test_dataset')
-            self.assertEqual(dataset.data.shape, (1, 141))
+            self.assertEqual(dataset.data.shape, (1, 147))
             self.assertEqual(dataset.data.seq_num.iloc[0], 240)
             self.assertIsNone(dataset.X_test)
 

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -625,9 +625,9 @@ class TestFeaturizer(unittest.TestCase):
             pcycler_run = loadfn(processed_cycler_run_path_1)
             v_vars_df = featurizer_helpers.get_v_diff(pcycler_run, 1, 8)
             print(v_vars_df)
-            self.assertEqual(np.round(v_vars_df.iloc[0]['var(v_diff)'], decimals=8),
+            self.assertEqual(np.round(v_vars_df.iloc[0]['var_v_diff'], decimals=8),
                              np.round(0.00472705, decimals=8))
-            self.assertListEqual(list(v_vars_df.columns), ["var(v_diff)", "min(v_diff)", "mean(v_diff)", "skew(v_diff)", "kurtosis(v_diff)", "sum(v_diff)", "sum_square(v_diff)"])
+            self.assertListEqual(list(v_vars_df.columns), ["var_v_diff", "min_v_diff", "mean_v_diff", "skew_v_diff", "kurtosis_v_diff", "sum_v_diff", "sum_square_v_diff"])
 
             temp_list = v_vars_df.iloc[0,:].to_list()
             temp_list = [np.round(np.float(x),8) for x in temp_list]
@@ -637,9 +637,9 @@ class TestFeaturizer(unittest.TestCase):
             pcycler_run = loadfn(processed_cycler_run_path_2)
             v_vars_df = featurizer_helpers.get_v_diff(pcycler_run, 1, 8)
             print(v_vars_df)
-            self.assertEqual(np.round(v_vars_df.iloc[0]['var(v_diff)'], decimals=8),
+            self.assertEqual(np.round(v_vars_df.iloc[0]['var_v_diff'], decimals=8),
                              np.round(2.664e-05, decimals=8))
-            self.assertListEqual(list(v_vars_df.columns), ["var(v_diff)", "min(v_diff)", "mean(v_diff)", "skew(v_diff)", "kurtosis(v_diff)", "sum(v_diff)", "sum_square(v_diff)"])
+            self.assertListEqual(list(v_vars_df.columns), ["var_v_diff", "min_v_diff", "mean_v_diff", "skew_v_diff", "kurtosis_v_diff", "sum_v_diff", "sum_square_v_diff"])
 
             temp_list = v_vars_df.iloc[0,:].to_list()
             temp_list = [np.round(np.float(x),8) for x in temp_list]
@@ -649,9 +649,9 @@ class TestFeaturizer(unittest.TestCase):
             pcycler_run = loadfn(processed_cycler_run_path_3)
             v_vars_df = featurizer_helpers.get_v_diff(pcycler_run, 1, 8)
             print(v_vars_df)
-            self.assertEqual(np.round(v_vars_df.iloc[0]['var(v_diff)'], decimals=8),
+            self.assertEqual(np.round(v_vars_df.iloc[0]['var_v_diff'], decimals=8),
                              np.round(4.82e-06, decimals=8))
-            self.assertListEqual(list(v_vars_df.columns), ["var(v_diff)", "min(v_diff)", "mean(v_diff)", "skew(v_diff)", "kurtosis(v_diff)", "sum(v_diff)", "sum_square(v_diff)"])
+            self.assertListEqual(list(v_vars_df.columns), ["var_v_diff", "min_v_diff", "mean_v_diff", "skew_v_diff", "kurtosis_v_diff", "sum_v_diff", "sum_square_v_diff"])
 
             temp_list = v_vars_df.iloc[0,:].to_list()
             temp_list = [np.round(np.float(x),8) for x in temp_list]
@@ -661,9 +661,9 @@ class TestFeaturizer(unittest.TestCase):
             pcycler_run = loadfn(processed_cycler_run_path_4)
             v_vars_df = featurizer_helpers.get_v_diff(pcycler_run, 1, 8)
             print(v_vars_df)
-            self.assertEqual(np.round(v_vars_df.iloc[0]['var(v_diff)'], decimals=8),
+            self.assertEqual(np.round(v_vars_df.iloc[0]['var_v_diff'], decimals=8),
                              np.round(9.71e-06, decimals=8))
-            self.assertListEqual(list(v_vars_df.columns), ["var(v_diff)", "min(v_diff)", "mean(v_diff)", "skew(v_diff)", "kurtosis(v_diff)", "sum(v_diff)", "sum_square(v_diff)"])
+            self.assertListEqual(list(v_vars_df.columns), ["var_v_diff", "min_v_diff", "mean_v_diff", "skew_v_diff", "kurtosis_v_diff", "sum_v_diff", "sum_square_v_diff"])
 
             temp_list = v_vars_df.iloc[0,:].to_list()
             temp_list = [np.round(np.float(x),8) for x in temp_list]

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -304,7 +304,7 @@ class TestFeaturizer(unittest.TestCase):
             folder = os.path.split(path)[-1]
             dumpfn(featurizer, featurizer.name)
             self.assertEqual(folder, "HPPCResistanceVoltageFeatures")
-            self.assertEqual(featurizer.X.shape[1], 70)
+            self.assertEqual(featurizer.X.shape[1], 76)
             self.assertListEqual(
                 [featurizer.X.columns[0], featurizer.X.columns[-1]],
                 ["ohmic_r_d0", "D_8"],
@@ -317,7 +317,13 @@ class TestFeaturizer(unittest.TestCase):
         os.environ["BEEP_PROCESSING_DIR"] = TEST_FILE_DIR
         pcycler_run = loadfn(pcycler_run_loc)
         hppc_ocv_features = featurizer_helpers.get_hppc_ocv(pcycler_run, 1)
-        self.assertEqual(np.round(hppc_ocv_features['variance of ocv'].iloc[0], 6), 0.000016)
+        self.assertEqual(np.round(hppc_ocv_features['var_ocv'].iloc[0], 6), 0.000016)
+        self.assertEqual(np.round(hppc_ocv_features['min_ocv'].iloc[0], 6), -0.001291)
+        self.assertEqual(np.round(hppc_ocv_features['mean_ocv'].iloc[0], 6), 0.002221)
+        self.assertEqual(np.round(hppc_ocv_features['skew_ocv'].iloc[0], 6), 1.589392)
+        self.assertEqual(np.round(hppc_ocv_features['kurtosis_ocv'].iloc[0], 6), 7.041016)
+        self.assertEqual(np.round(hppc_ocv_features['sum_ocv'].iloc[0], 6), 0.025126)
+        self.assertEqual(np.round(hppc_ocv_features['sum_square_ocv'].iloc[0], 6), 0.000188)
 
     def test_get_step_index(self):
         pcycler_run_loc = os.path.join(


### PR DESCRIPTION
This PR adds additional statistics to `get_hppc_ocv()` as well as standardizes the `get_v_diff()` keys.

Tests have been added to check the output, but need to be checked by a researcher.