### PR TITLE
Change pandas indexing usage to use iloc instead of straight lists

### DIFF
--- a/beep/featurize.py
+++ b/beep/featurize.py
@@ -1030,6 +1030,7 @@ class DeltaQFastCharge(BeepFeatures):
                 len(processed_cycler_run.summary.index)
                 > params_dict["final_pred_cycle"]
             )
+        conditions.append("cycle_index" in processed_cycler_run.cycles_interpolated.columns)
 
         return all(conditions)
 

--- a/beep/featurize.py
+++ b/beep/featurize.py
@@ -1074,26 +1074,26 @@ class DeltaQFastCharge(BeepFeatures):
         X = pd.DataFrame(np.zeros((1, 20)))
         labels = []
         # Discharge capacity, cycle 2 = Q(n=2)
-        X[0] = summary.discharge_capacity[1]
+        X[0] = summary.discharge_capacity.iloc[1]
         labels.append("discharge_capacity_cycle_2")
 
         # Max discharge capacity - discharge capacity, cycle 2 = max_n(Q(n)) - Q(n=2)
         X[1] = max(
-            summary.discharge_capacity[np.arange(i_final + 1)]
-            - summary.discharge_capacity[1]
+            summary.discharge_capacity.iloc[np.arange(i_final + 1)]
+            - summary.discharge_capacity.iloc[1]
         )
         labels.append("max_discharge_capacity_difference")
 
         # Discharge capacity, cycle 100 = Q(n=100)
-        X[2] = summary.discharge_capacity[i_final]
+        X[2] = summary.discharge_capacity.iloc[i_final]
         labels.append("discharge_capacity_cycle_100")
 
         # Feature representing time-temperature integral over cycles 2 to 100
-        X[3] = np.nansum(summary.time_temperature_integrated[np.arange(i_final + 1)])
+        X[3] = np.nansum(summary.time_temperature_integrated.iloc[np.arange(i_final + 1)])
         labels.append("integrated_time_temperature_cycles_1:100")
 
         # Mean of charge times of first 5 cycles
-        X[4] = np.nanmean(summary.charge_duration[1:6])
+        X[4] = np.nanmean(summary.charge_duration.iloc[1:6])
         labels.append("charge_time_cycles_1:5")
 
         # Descriptors based on capacity loss between cycles 10 and 100.
@@ -1123,17 +1123,17 @@ class DeltaQFastCharge(BeepFeatures):
         labels.append("abs_kurtosis_discharge_capacity_difference_cycles_2:100")
         labels.append("abs_first_discharge_capacity_difference_cycles_2:100")
 
-        X[11] = max(summary.temperature_maximum[list(range(1, i_final + 1))])  # Max T
+        X[11] = np.max(summary.temperature_maximum.iloc[list(range(1, i_final + 1))])  # Max T
         labels.append("max_temperature_cycles_1:100")
 
-        X[12] = min(summary.temperature_minimum[list(range(1, i_final + 1))])  # Min T
+        X[12] = np.min(summary.temperature_minimum.iloc[list(range(1, i_final + 1))])  # Min T
         labels.append("min_temperature_cycles_1:100")
 
         # Slope and intercept of linear fit to discharge capacity as a fn of cycle #, cycles 2 to 100
 
         X[13], X[14] = np.polyfit(
             list(range(1, i_final + 1)),
-            summary.discharge_capacity[list(range(1, i_final + 1))],
+            summary.discharge_capacity.iloc[list(range(1, i_final + 1))],
             1,
         )
 
@@ -1143,13 +1143,13 @@ class DeltaQFastCharge(BeepFeatures):
         # Slope and intercept of linear fit to discharge capacity as a fn of cycle #, cycles 91 to 100
         X[15], X[16] = np.polyfit(
             list(range(i_mid, i_final + 1)),
-            summary.discharge_capacity[list(range(i_mid, i_final + 1))],
+            summary.discharge_capacity.iloc[list(range(i_mid, i_final + 1))],
             1,
         )
         labels.append("slope_discharge_capacity_cycle_number_91:100")
         labels.append("intercept_discharge_capacity_cycle_number_91:100")
 
-        IR_trend = summary.dc_internal_resistance[list(range(1, i_final + 1))]
+        IR_trend = summary.dc_internal_resistance.iloc[list(range(1, i_final + 1))]
         if any(v == 0 for v in IR_trend):
             IR_trend[IR_trend == 0] = np.nan
 
@@ -1158,12 +1158,12 @@ class DeltaQFastCharge(BeepFeatures):
         labels.append("min_internal_resistance_cycles_2:100")
 
         # Internal resistance at cycle 2
-        X[18] = summary.dc_internal_resistance[1]
+        X[18] = summary.dc_internal_resistance.iloc[1]
         labels.append("internal_resistance_cycle_2")
 
         # Internal resistance at cycle 100 - cycle 2
         X[19] = (
-            summary.dc_internal_resistance[i_final] - summary.dc_internal_resistance[1]
+            summary.dc_internal_resistance.iloc[i_final] - summary.dc_internal_resistance.iloc[1]
         )
         labels.append("internal_resistance_difference_cycles_2:100")
 

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -40,8 +40,6 @@ from beep.utils.s3 import download_s3_object
 
 TEST_DIR = os.path.dirname(__file__)
 TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
-PROCESSED_CYCLER_FILE = "2017-06-30_2C-10per_6C_CH10_structure.json"
-PROCESSED_CYCLER_FILE_INSUF = "structure_insufficient.json"
 MACCOR_FILE_W_DIAGNOSTICS = os.path.join(TEST_FILE_DIR, "xTESLADIAG_000020_CH71.071")
 MACCOR_FILE_W_PARAMETERS = os.path.join(
     TEST_FILE_DIR, "PredictionDiagnostics_000109_tztest.010"
@@ -53,10 +51,12 @@ SKIP_MSG = "Tests requiring large files with diagnostic cycles are disabled, set
 
 class TestFeaturizer(unittest.TestCase):
     def setUp(self):
+        self.processed_cycler_file = "2017-06-30_2C-10per_6C_CH10_structure.json"
+        self.processed_cycler_file_insuf = "structure_insufficient.json"
         pass
 
     def test_feature_generation_full_model(self):
-        processed_cycler_run_path = os.path.join(TEST_FILE_DIR, PROCESSED_CYCLER_FILE)
+        processed_cycler_run_path = os.path.join(TEST_FILE_DIR, self.processed_cycler_file)
         with ScratchDir("."):
             os.environ["BEEP_PROCESSING_DIR"] = os.getcwd()
             pcycler_run = loadfn(processed_cycler_run_path)
@@ -66,10 +66,13 @@ class TestFeaturizer(unittest.TestCase):
 
             self.assertEqual(len(featurizer.X), 1)  # just test if works for now
             # Ensure no NaN values
+            print(featurizer.X.to_dict())
             self.assertFalse(np.any(featurizer.X.isnull()))
+            self.assertEqual(np.round(featurizer.X.loc[0, 'intercept_discharge_capacity_cycle_number_91:100'], 6),
+                             np.round(1.1050065801818196, 6))
 
     def test_feature_old_class(self):
-        processed_cycler_run_path = os.path.join(TEST_FILE_DIR, PROCESSED_CYCLER_FILE)
+        processed_cycler_run_path = os.path.join(TEST_FILE_DIR, self.processed_cycler_file)
         with ScratchDir("."):
             os.environ["BEEP_PROCESSING_DIR"] = os.getcwd()
             predictor = DegradationPredictor.from_processed_cycler_run_file(
@@ -78,7 +81,7 @@ class TestFeaturizer(unittest.TestCase):
             self.assertEqual(predictor.feature_labels[4], "charge_time_cycles_1:5")
 
     def test_feature_label_full_model(self):
-        processed_cycler_run_path = os.path.join(TEST_FILE_DIR, PROCESSED_CYCLER_FILE)
+        processed_cycler_run_path = os.path.join(TEST_FILE_DIR, self.processed_cycler_file)
         with ScratchDir("."):
             os.environ["BEEP_PROCESSING_DIR"] = os.getcwd()
             pcycler_run = loadfn(processed_cycler_run_path)
@@ -89,7 +92,7 @@ class TestFeaturizer(unittest.TestCase):
             self.assertEqual(featurizer.X.columns.tolist()[4], "charge_time_cycles_1:5")
 
     def test_feature_serialization(self):
-        processed_cycler_run_path = os.path.join(TEST_FILE_DIR, PROCESSED_CYCLER_FILE)
+        processed_cycler_run_path = os.path.join(TEST_FILE_DIR, self.processed_cycler_file)
         with ScratchDir("."):
             os.environ["BEEP_PROCESSING_DIR"] = os.getcwd()
             pcycler_run = loadfn(processed_cycler_run_path)
@@ -107,7 +110,7 @@ class TestFeaturizer(unittest.TestCase):
             )
 
     def test_feature_serialization_for_training(self):
-        processed_cycler_run_path = os.path.join(TEST_FILE_DIR, PROCESSED_CYCLER_FILE)
+        processed_cycler_run_path = os.path.join(TEST_FILE_DIR, self.processed_cycler_file)
         with ScratchDir("."):
             os.environ["BEEP_PROCESSING_DIR"] = os.getcwd()
             pcycler_run = loadfn(processed_cycler_run_path)
@@ -232,7 +235,7 @@ class TestFeaturizer(unittest.TestCase):
 
     def test_insufficient_data_file(self):
         processed_cycler_run_path = os.path.join(
-            TEST_FILE_DIR, PROCESSED_CYCLER_FILE_INSUF
+            TEST_FILE_DIR, self.processed_cycler_file_insuf
         )
         with ScratchDir("."):
             os.environ["BEEP_PROCESSING_DIR"] = os.getcwd()


### PR DESCRIPTION
This PR updates the DeltaQFastCharge feature class to use standard pandas indexing selection instead of lists. Output of the feature class is unchanged in tests.
- Passes index lists to `.iloc` which has the required behavior
- Add condition for creating the feature class to ensure basic indexing columns are present