### PR TITLE
refactor DashOrderedDict.get to DashOrderedDict.get_path

### DIFF
--- a/beep/protocol/arbin.py
+++ b/beep/protocol/arbin.py
@@ -89,7 +89,7 @@ class Schedule(DashOrderedDict):
         flat_keys.reverse()  # Reverse ensures sub-dicts are removed first
         data_tuples = []
         for flat_key in flat_keys:
-            data_tuple = (flat_key.replace(".", "_"), data.get(flat_key))
+            data_tuple = (flat_key.replace(".", "_"), data.get_path(flat_key))
             data_tuples.append(data_tuple)
             data.unset(flat_key)
         data_tuples.reverse()
@@ -155,7 +155,7 @@ class Schedule(DashOrderedDict):
         """
         # Find all step labels
         labelled_steps = filter(
-            lambda x: self.get("Schedule.{}.m_szLabel".format(x)) == step_label,
+            lambda x: self.get_path("Schedule.{}.m_szLabel".format(x)) == step_label,
             self["Schedule"].keys(),
         )
         return labelled_steps
@@ -209,7 +209,7 @@ class Schedule(DashOrderedDict):
         labelled_steps = self.get_labelled_steps(step_label)
         for step in labelled_steps:
             # Get all matching limit keys
-            step_data = self.get("Schedule.{}".format(step))
+            step_data = self.get_path("Schedule.{}".format(step))
             limits = [
                 heading
                 for heading in _get_headings(step_data)

--- a/beep/protocol/biologic.py
+++ b/beep/protocol/biologic.py
@@ -191,117 +191,117 @@ class Settings(DashOrderedDict):
         Returns:
             (self): returns the parameterized protocol
         """
-        assert self.get("Metadata.Cycle Definition") == "Charge/Discharge alternance"
+        assert self.get_path("Metadata.Cycle Definition") == "Charge/Discharge alternance"
 
         # Initial charge
-        assert self.get("Technique.1.Step.2.ctrl_type") == "CC"
-        assert self.get("Technique.1.Step.2.ctrl1_val_unit") == "A"
+        assert self.get_path("Technique.1.Step.2.ctrl_type") == "CC"
+        assert self.get_path("Technique.1.Step.2.ctrl1_val_unit") == "A"
         value = float(round(params["initial_charge_current_1"] * params['capacity_nominal'], 3))
         self.set("Technique.1.Step.2.ctrl1_val", value)
 
-        assert self.get("Technique.1.Step.2.lim1_type") == "Ecell"
-        assert self.get("Technique.1.Step.2.lim1_value_unit") == "V"
+        assert self.get_path("Technique.1.Step.2.lim1_type") == "Ecell"
+        assert self.get_path("Technique.1.Step.2.lim1_value_unit") == "V"
         value = float(round(params["initial_charge_voltage_1"], 3))
         self.set("Technique.1.Step.2.lim1_value", value)
-        assert self.get("Technique.1.Step.3.ctrl_type") == "CV"
-        assert self.get("Technique.1.Step.3.ctrl1_val_unit") == "V"
+        assert self.get_path("Technique.1.Step.3.ctrl_type") == "CV"
+        assert self.get_path("Technique.1.Step.3.ctrl1_val_unit") == "V"
         self.set("Technique.1.Step.3.ctrl1_val", value)
 
-        assert self.get("Technique.1.Step.3.lim1_type") == "Time"
-        assert self.get("Technique.1.Step.3.lim1_value_unit") == "mn"
+        assert self.get_path("Technique.1.Step.3.lim1_type") == "Time"
+        assert self.get_path("Technique.1.Step.3.lim1_value_unit") == "mn"
         value = float(round(params["initial_charge_cvhold_1"], 3))
         self.set("Technique.1.Step.3.lim1_value", value)
 
-        assert self.get("Technique.1.Step.4.lim1_type") == "Time"
-        assert self.get("Technique.1.Step.4.lim1_value_unit") == "mn"
+        assert self.get_path("Technique.1.Step.4.lim1_type") == "Time"
+        assert self.get_path("Technique.1.Step.4.lim1_value_unit") == "mn"
         value = float(round(params["initial_charge_rest_1"], 3))
         self.set("Technique.1.Step.4.lim1_value", value)
 
-        assert self.get("Technique.1.Step.5.ctrl_type") == "CC"
-        assert self.get("Technique.1.Step.5.ctrl1_val_unit") == "A"
+        assert self.get_path("Technique.1.Step.5.ctrl_type") == "CC"
+        assert self.get_path("Technique.1.Step.5.ctrl1_val_unit") == "A"
         value = float(round(params["initial_charge_current_2"] * params['capacity_nominal'], 3))
         self.set("Technique.1.Step.5.ctrl1_val", value)
 
-        assert self.get("Technique.1.Step.5.lim1_type") == "Ecell"
-        assert self.get("Technique.1.Step.5.lim1_value_unit") == "V"
+        assert self.get_path("Technique.1.Step.5.lim1_type") == "Ecell"
+        assert self.get_path("Technique.1.Step.5.lim1_value_unit") == "V"
         value = float(round(params["initial_charge_voltage_2"], 3))
         self.set("Technique.1.Step.5.lim1_value", value)
-        assert self.get("Technique.1.Step.6.ctrl_type") == "CV"
-        assert self.get("Technique.1.Step.6.ctrl1_val_unit") == "V"
+        assert self.get_path("Technique.1.Step.6.ctrl_type") == "CV"
+        assert self.get_path("Technique.1.Step.6.ctrl1_val_unit") == "V"
         self.set("Technique.1.Step.6.ctrl1_val", value)
 
-        assert self.get("Technique.1.Step.6.lim1_type") == "Time"
-        assert self.get("Technique.1.Step.6.lim1_value_unit") == "mn"
+        assert self.get_path("Technique.1.Step.6.lim1_type") == "Time"
+        assert self.get_path("Technique.1.Step.6.lim1_value_unit") == "mn"
         value = float(round(params["initial_charge_cvhold_2"], 3))
         self.set("Technique.1.Step.6.lim1_value", value)
 
-        assert self.get("Technique.1.Step.7.lim1_type") == "Time"
-        assert self.get("Technique.1.Step.7.lim1_value_unit") == "mn"
+        assert self.get_path("Technique.1.Step.7.lim1_type") == "Time"
+        assert self.get_path("Technique.1.Step.7.lim1_value_unit") == "mn"
         value = float(round(params["initial_charge_rest_2"], 3))
         self.set("Technique.1.Step.7.lim1_value", value)
 
         # Initial discharge
-        assert self.get("Technique.1.Step.8.ctrl_type") == "CC"
-        assert self.get("Technique.1.Step.8.ctrl1_val_unit") == "A"
+        assert self.get_path("Technique.1.Step.8.ctrl_type") == "CC"
+        assert self.get_path("Technique.1.Step.8.ctrl1_val_unit") == "A"
         value = float(round(params["initial_discharge_current_1"] * params['capacity_nominal'], 3))
         self.set("Technique.1.Step.8.ctrl1_val", value)
 
-        assert self.get("Technique.1.Step.8.lim1_type") == "Ecell"
-        assert self.get("Technique.1.Step.8.lim1_value_unit") == "V"
+        assert self.get_path("Technique.1.Step.8.lim1_type") == "Ecell"
+        assert self.get_path("Technique.1.Step.8.lim1_value_unit") == "V"
         value = float(round(params["initial_discharge_voltage_1"], 3))
         self.set("Technique.1.Step.8.lim1_value", value)
 
         # Mid cycle
-        assert self.get("Technique.1.Step.9.ctrl_type") == "CC"
-        assert self.get("Technique.1.Step.9.ctrl1_val_unit") == "A"
+        assert self.get_path("Technique.1.Step.9.ctrl_type") == "CC"
+        assert self.get_path("Technique.1.Step.9.ctrl1_val_unit") == "A"
         value = float(round(params["mid_charge_current_1"] * params['capacity_nominal'], 3))
         self.set("Technique.1.Step.9.ctrl1_val", value)
 
-        assert self.get("Technique.1.Step.9.lim1_type") == "Ecell"
-        assert self.get("Technique.1.Step.9.lim1_value_unit") == "V"
+        assert self.get_path("Technique.1.Step.9.lim1_type") == "Ecell"
+        assert self.get_path("Technique.1.Step.9.lim1_value_unit") == "V"
         value = float(round(params["mid_charge_voltage_1"], 3))
         self.set("Technique.1.Step.9.lim1_value", value)
 
-        assert self.get("Technique.1.Step.10.ctrl_type") == "CC"
-        assert self.get("Technique.1.Step.10.ctrl1_val_unit") == "A"
+        assert self.get_path("Technique.1.Step.10.ctrl_type") == "CC"
+        assert self.get_path("Technique.1.Step.10.ctrl1_val_unit") == "A"
         value = float(round(params["mid_discharge_current_1"] * params['capacity_nominal'], 3))
         self.set("Technique.1.Step.10.ctrl1_val", value)
 
-        assert self.get("Technique.1.Step.10.lim1_type") == "Ecell"
-        assert self.get("Technique.1.Step.10.lim1_value_unit") == "V"
+        assert self.get_path("Technique.1.Step.10.lim1_type") == "Ecell"
+        assert self.get_path("Technique.1.Step.10.lim1_value_unit") == "V"
         value = float(round(params["mid_discharge_voltage_1"], 3))
         self.set("Technique.1.Step.10.lim1_value", value)
 
-        assert self.get("Technique.1.Step.11.ctrl_type") == "Loop"
-        assert self.get("Technique.1.Step.11.ctrl_seq") == "8"
+        assert self.get_path("Technique.1.Step.11.ctrl_type") == "Loop"
+        assert self.get_path("Technique.1.Step.11.ctrl_seq") == "8"
         value = int(params["mid_cycle_reps"] - 1)
         self.set("Technique.1.Step.11.ctrl_repeat", value)
 
         # Final cycle
-        assert self.get("Technique.1.Step.12.ctrl_type") == "CC"
-        assert self.get("Technique.1.Step.12.ctrl1_val_unit") == "A"
+        assert self.get_path("Technique.1.Step.12.ctrl_type") == "CC"
+        assert self.get_path("Technique.1.Step.12.ctrl1_val_unit") == "A"
         value = float(round(params["final_charge_current_1"] * params['capacity_nominal'], 3))
         self.set("Technique.1.Step.12.ctrl1_val", value)
 
-        assert self.get("Technique.1.Step.12.lim1_type") == "Ecell"
-        assert self.get("Technique.1.Step.12.lim1_value_unit") == "V"
+        assert self.get_path("Technique.1.Step.12.lim1_type") == "Ecell"
+        assert self.get_path("Technique.1.Step.12.lim1_value_unit") == "V"
         value = float(round(params["final_charge_voltage_1"], 3))
         self.set("Technique.1.Step.12.lim1_value", value)
 
-        assert self.get("Technique.1.Step.13.ctrl_type") == "CC"
-        assert self.get("Technique.1.Step.13.ctrl1_val_unit") == "A"
+        assert self.get_path("Technique.1.Step.13.ctrl_type") == "CC"
+        assert self.get_path("Technique.1.Step.13.ctrl1_val_unit") == "A"
         value = float(round(params["final_discharge_current_1"] * params['capacity_nominal'], 3))
         self.set("Technique.1.Step.13.ctrl1_val", value)
 
-        assert self.get("Technique.1.Step.13.lim1_type") == "Ecell"
-        assert self.get("Technique.1.Step.13.lim1_value_unit") == "V"
+        assert self.get_path("Technique.1.Step.13.lim1_type") == "Ecell"
+        assert self.get_path("Technique.1.Step.13.lim1_value_unit") == "V"
         value = float(round(params["final_discharge_voltage_1"], 3))
         self.set("Technique.1.Step.13.lim1_value", value)
-        assert self.get("Technique.1.Step.14.ctrl_type") == "CV"
-        assert self.get("Technique.1.Step.14.ctrl1_val_unit") == "V"
+        assert self.get_path("Technique.1.Step.14.ctrl_type") == "CV"
+        assert self.get_path("Technique.1.Step.14.ctrl1_val_unit") == "V"
         self.set("Technique.1.Step.14.ctrl1_val", value)
-        assert self.get("Technique.1.Step.14.lim1_type") == "Time"
-        assert self.get("Technique.1.Step.14.lim1_value_unit") == "mn"
+        assert self.get_path("Technique.1.Step.14.lim1_type") == "Time"
+        assert self.get_path("Technique.1.Step.14.lim1_value_unit") == "mn"
         value = float(round(params["final_discharge_cvhold_1"], 3))
         self.set("Technique.1.Step.14.lim1_value", value)
 

--- a/beep/tests/test_protocol.py
+++ b/beep/tests/test_protocol.py
@@ -571,12 +571,12 @@ class GenerateProcedureTest(unittest.TestCase):
                 discharge_df = waveform_df[waveform_df[0] == "D"]
                 self.assertGreaterEqual(discharge_df[4].abs().max(), MIN_PROFILE_VOLTAGE)
 
-                self.assertEqual(protocol.get("MaccorTestProcedure.ProcSteps.TestStep.32.StepType"), 'FastWave')
-                self.assertEqual(protocol.get("MaccorTestProcedure.ProcSteps.TestStep.64.StepType"), 'FastWave')
+                self.assertEqual(protocol.get_path("MaccorTestProcedure.ProcSteps.TestStep.32.StepType"), 'FastWave')
+                self.assertEqual(protocol.get_path("MaccorTestProcedure.ProcSteps.TestStep.64.StepType"), 'FastWave')
                 wave_value = os.path.split(waveform_name)[-1].split(".")[0]
-                self.assertEqual(protocol.get("MaccorTestProcedure.ProcSteps.TestStep.32.StepValue"),
+                self.assertEqual(protocol.get_path("MaccorTestProcedure.ProcSteps.TestStep.32.StepValue"),
                                  wave_value)
-                self.assertEqual(protocol.get("MaccorTestProcedure.ProcSteps.TestStep.64.StepValue"),
+                self.assertEqual(protocol.get_path("MaccorTestProcedure.ProcSteps.TestStep.64.StepValue"),
                                  wave_value)
 
             self.assertEqual(len(os.listdir(os.path.join(output_directory, "procedures"))), 36)
@@ -1198,7 +1198,7 @@ class BiologicSettingsTest(unittest.TestCase):
         filename = "BCS - 171.64.160.115_Ta19_ourprotocol_gdocSEP2019_CC7.mps"
         bcs = Settings.from_file(os.path.join(BIOLOGIC_TEMPLATE_DIR, filename))
         self.assertEqual(len(bcs["Technique"]["1"]["Step"].keys()), 55)
-        self.assertEqual(bcs.get("Technique.1.Step.5.Ns"), "4")
+        self.assertEqual(bcs.get_path("Technique.1.Step.5.Ns"), "4")
         self.assertEqual(bcs["Technique"]["1"]["Type"], "Modulo Bat")
         self.assertEqual(bcs["Metadata"]["BT-LAB SETTING FILE"], None)
         self.assertEqual(bcs["Metadata"]["line3"], "blank")
@@ -1224,7 +1224,7 @@ class BiologicSettingsTest(unittest.TestCase):
         bcs = Settings.from_file(os.path.join(BIOLOGIC_TEMPLATE_DIR, filename))
         value = "{:.3f}".format(5)
         bcs.set("Technique.1.Step.3.ctrl1_val", value)
-        self.assertEqual(bcs.get("Technique.1.Step.3.ctrl1_val"), "5.000")
+        self.assertEqual(bcs.get_path("Technique.1.Step.3.ctrl1_val"), "5.000")
         test_name = "test.mps"
         with ScratchDir("."):
             bcs.to_file(test_name)
@@ -1259,22 +1259,22 @@ class BiologicSettingsTest(unittest.TestCase):
                 if template == "formationV1.mps":
                     bcs = Settings.from_file(os.path.join(BIOLOGIC_TEMPLATE_DIR, filename))
 
-                    self.assertEqual(bcs.get("Metadata.Cycle Definition"), "Charge/Discharge alternance")
+                    self.assertEqual(bcs.get_path("Metadata.Cycle Definition"), "Charge/Discharge alternance")
                     bcs = bcs.formation_protocol_bcs(protocol_params)
-                    self.assertEqual(bcs.get("Technique.1.Step.2.ctrl1_val"), float(round(0.2 * 0.1, 3)))
-                    self.assertEqual(bcs.get("Technique.1.Step.3.lim1_value"), float(round(60, 3)))
-                    self.assertEqual(bcs.get("Technique.1.Step.4.lim1_value"), float(round(30, 3)))
-                    self.assertEqual(bcs.get("Technique.1.Step.5.ctrl1_val"), float(round(0.2 * 0.2, 3)))
-                    self.assertEqual(bcs.get("Technique.1.Step.6.lim1_value"), float(round(30, 3)))
-                    self.assertEqual(bcs.get("Technique.1.Step.7.lim1_value"), float(round(30, 3)))
-                    self.assertEqual(bcs.get("Technique.1.Step.8.ctrl1_val"), float(round(0.2 * 0.2, 3)))
-                    self.assertEqual(bcs.get("Technique.1.Step.8.lim1_value"), float(round(3.0, 3)))
-                    self.assertEqual(bcs.get("Technique.1.Step.9.ctrl1_val"), float(round(0.2 * 0.5, 3)))
-                    self.assertEqual(bcs.get("Technique.1.Step.10.lim1_value"), float(round(3.9, 3)))
-                    self.assertEqual(bcs.get("Technique.1.Step.11.ctrl_repeat"), int(1))
-                    self.assertEqual(bcs.get("Technique.1.Step.12.ctrl1_val"), float(round(0.2 * 1, 3)))
-                    self.assertEqual(bcs.get("Technique.1.Step.13.lim1_value"), float(round(3.5, 3)))
-                    self.assertEqual(bcs.get("Technique.1.Step.14.ctrl1_val"), float(round(3.5, 3)))
+                    self.assertEqual(bcs.get_path("Technique.1.Step.2.ctrl1_val"), float(round(0.2 * 0.1, 3)))
+                    self.assertEqual(bcs.get_path("Technique.1.Step.3.lim1_value"), float(round(60, 3)))
+                    self.assertEqual(bcs.get_path("Technique.1.Step.4.lim1_value"), float(round(30, 3)))
+                    self.assertEqual(bcs.get_path("Technique.1.Step.5.ctrl1_val"), float(round(0.2 * 0.2, 3)))
+                    self.assertEqual(bcs.get_path("Technique.1.Step.6.lim1_value"), float(round(30, 3)))
+                    self.assertEqual(bcs.get_path("Technique.1.Step.7.lim1_value"), float(round(30, 3)))
+                    self.assertEqual(bcs.get_path("Technique.1.Step.8.ctrl1_val"), float(round(0.2 * 0.2, 3)))
+                    self.assertEqual(bcs.get_path("Technique.1.Step.8.lim1_value"), float(round(3.0, 3)))
+                    self.assertEqual(bcs.get_path("Technique.1.Step.9.ctrl1_val"), float(round(0.2 * 0.5, 3)))
+                    self.assertEqual(bcs.get_path("Technique.1.Step.10.lim1_value"), float(round(3.9, 3)))
+                    self.assertEqual(bcs.get_path("Technique.1.Step.11.ctrl_repeat"), int(1))
+                    self.assertEqual(bcs.get_path("Technique.1.Step.12.ctrl1_val"), float(round(0.2 * 1, 3)))
+                    self.assertEqual(bcs.get_path("Technique.1.Step.13.lim1_value"), float(round(3.5, 3)))
+                    self.assertEqual(bcs.get_path("Technique.1.Step.14.ctrl1_val"), float(round(3.5, 3)))
 
                 test_name = "{}.mps".format(filename_prefix)
                 test_name = os.path.join(scratch_dir, "settings", test_name)

--- a/beep/utils/__init__.py
+++ b/beep/utils/__init__.py
@@ -23,8 +23,8 @@ class DashOrderedDict(OrderedDict):
     def set(self, string, value):
         set_with(self, string, value, lambda x: OrderedDict())
 
-    def get(self, string):
-        return get(self, string)
+    def get_path(self, string, default=None):
+        return get(self, string, default=default)
 
     def unset(self, string):
         unset(self, string)


### PR DESCRIPTION
Updates `DashOrderedDict.get` (which previously overrided the OrderedDict.get method) - to `get_path`, which doesn't interfere with the new pydash api.