### PR TITLE
MAT-2489: Make Environment Variables Optional

### DIFF
--- a/beep/__init__.py
+++ b/beep/__init__.py
@@ -38,18 +38,14 @@ MAX_RETRIES = 12
 # environment
 ENVIRONMENT = os.getenv(ENV_VAR)
 if ENVIRONMENT is None or ENVIRONMENT not in config.keys():
-    raise ValueError(
-        f"Environment variable {ENV_VAR} must be set and be one "
-        + f'of the following: {", ".join(list(config.keys()))}. '
-        + f"Found: {ENVIRONMENT}"
-    )
+    ENVIRONMENT = "local"
 
 DIR = os.getenv(PROCESSED_DIR)
 if DIR is None:
     if ENVIRONMENT in ["stage", "prod"]:
         os.environ[PROCESSED_DIR] = "/"
     elif ENVIRONMENT in ["local", "dev", "test"]:
-        os.environ[PROCESSED_DIR] = os.path.dirname(__file__)
+        os.environ[PROCESSED_DIR] = os.getcwd()
     else:
         raise ValueError(
             f"The directory for processing cycling data {PROCESSED_DIR} must be set"


### PR DESCRIPTION
This PR makes the `BEEP_ENV` and `BEEP_PROCESSING_DIR` environment variables optional by defaulting to `local` for `BEEP_ENV` and the current working directory for `BEEP_PROCESSING_DIR`.

Fixes #116 