### PR TITLE
Mat 2580 no loop unrolling

### DIFF
--- a/beep/protocol/maccor_to_biologic_mb.py
+++ b/beep/protocol/maccor_to_biologic_mb.py
@@ -609,7 +609,7 @@ class MaccorToBiologicMb:
                 loop_unroll_status_by_idx[idx] = {"will_unroll": curr_loop_will_unroll}
                 loop_will_unroll_stack.pop()
 
-                if curr_loop_will_unroll:
+                if False: # curr_loop_will_unroll:
                     # add unrolled loop seqs
 
                     # first add tracking data
@@ -632,7 +632,7 @@ class MaccorToBiologicMb:
                 # physical step
 
                 # last step in loop does not advance cycle, must unroll
-                if is_last_step_in_loop:
+                if False: # is_last_step_in_loop:
                     loop_will_unroll_stack[-1] = True
 
                 if get(step, "Limits.Current") or get(step, "Limits.Voltage"):
@@ -678,7 +678,7 @@ class MaccorToBiologicMb:
                 loop_will_unoll = loop_unroll_status_by_idx[idx]["will_unroll"]
                 loop = seq_loop_stack.pop()
 
-                if loop_will_unoll:
+                if False: # loop_will_unoll:
                     unrolled_loop = self._unroll_loop(
                         loop, num_loops, loop_start_seq_num, seq_num
                     )

--- a/beep/protocol/maccor_to_biologic_mb.py
+++ b/beep/protocol/maccor_to_biologic_mb.py
@@ -524,7 +524,7 @@ class MaccorToBiologicMb:
         - a list of biologic seqs
     """
 
-    def maccor_ast_to_biologic_seqs(self, maccor_ast):
+    def maccor_ast_to_biologic_seqs(self, maccor_ast, unroll=False):
         steps = get(maccor_ast, "MaccorTestProcedure.ProcSteps.TestStep")
         if steps is None:
             print(
@@ -532,7 +532,7 @@ class MaccorToBiologicMb:
             )
             return
 
-        seqs, _ = self._maccor_steps_to_biologic_seqs(steps)
+        seqs, _ = self._maccor_steps_to_biologic_seqs(steps, unroll=unroll)
         return seqs
 
     """
@@ -842,8 +842,8 @@ class MaccorToBiologicMb:
     LATIN-1 i.e. ISO-8859-1 encoding
     """
 
-    def maccor_ast_to_protocol_str(self, maccor_ast, col_width=20):
-        seqs = self.maccor_ast_to_biologic_seqs(maccor_ast)
+    def maccor_ast_to_protocol_str(self, maccor_ast, unroll=False, col_width=20):
+        seqs = self.maccor_ast_to_biologic_seqs(maccor_ast, unroll=unroll)
         return self.biologic_seqs_to_protocol_str(seqs, col_width)
 
     """

--- a/beep/protocol/maccor_to_biologic_mb.py
+++ b/beep/protocol/maccor_to_biologic_mb.py
@@ -149,13 +149,16 @@ class MaccorToBiologicMb:
             return "{:.3f}".format(total_time_sec), "s"
 
     def _proc_step_to_seq(
-        self, proc_step, step_num, seq_from_step_num, goto_lower_bound, end_step_num, current_range='10 A'
+        self, proc_step, step_num, seq_from_step_num, goto_lower_bound, end_step_num,
+            current_range='10 A', split_step=None
     ):
         """
         converts steps that are not related to control flow to sequence dicts
         (control flow steps are DO, LOOP, ADV CYCLE)
         """
         seq_num = seq_from_step_num[step_num]
+        if split_step == "pt2":
+            seq_num = seq_num + 1
         assert seq_num is not None
 
         new_seq = self.blank_seq.copy()
@@ -216,7 +219,7 @@ class MaccorToBiologicMb:
             # does this need to be formatted? e.g. 1.0 from Maccor vs 1.000 for biologic
             assert type(step_value) == str
 
-            ctrl1_val, ctrl1_val_unit = self._convert_amps(step_value)
+            ctrl1_val, ctrl1_val_unit = self._convert_volts(step_value)
             new_seq["ctrl1_val"] = ctrl1_val
             new_seq["ctrl1_val_unit"] = ctrl1_val_unit
 
@@ -287,7 +290,10 @@ class MaccorToBiologicMb:
                 )
 
             assert goto_step_num in seq_from_step_num
-            goto_seq = seq_from_step_num[goto_step_num]
+            if split_step == "pt1":
+                goto_seq = seq_num + 1
+            else:
+                goto_seq = seq_from_step_num[goto_step_num]
             new_seq["lim{}_seq".format(lim_num)] = goto_seq
 
             if goto_step_num != step_num + 1:
@@ -329,7 +335,7 @@ class MaccorToBiologicMb:
                 lim_value, lim_value_unit = self._convert_amps(end_value)
 
                 new_seq["lim{0}_comp".format(lim_num)] = operator_map[end_oper]
-                new_seq["lim{0}_type".format(lim_num)] = "I"
+                new_seq["lim{0}_type".format(lim_num)] = "|I|"
                 new_seq["lim{0}_value".format(lim_num)] = lim_value
                 new_seq["lim{0}_value_unit".format(lim_num)] = lim_value_unit
             else:
@@ -430,6 +436,7 @@ class MaccorToBiologicMb:
                 raise NotImplementedError
             step_part1["StepMode"] = "Current"
             step_part1["StepValue"] = step["Limits"]["Current"]
+            set_(step_part1, path + ".EndType", "Voltage")
             set_(step_part1, path + ".Value", step["StepValue"])
             set_(step_part1, path + ".Step", str(step_num + 1).zfill(3))
             step_part1["Limits"] = None
@@ -540,7 +547,7 @@ class MaccorToBiologicMb:
           seqs are 0-indexed, steps are 1-indexed
     """
 
-    def _maccor_steps_to_biologic_seqs(self, steps):
+    def _maccor_steps_to_biologic_seqs(self, steps, unroll=False):
 
         # To build our seqs we need to be able to handle GOTOs
         # in order to do that we a mapping between Step Numbers
@@ -609,7 +616,7 @@ class MaccorToBiologicMb:
                 loop_unroll_status_by_idx[idx] = {"will_unroll": curr_loop_will_unroll}
                 loop_will_unroll_stack.pop()
 
-                if False: # curr_loop_will_unroll:
+                if unroll and curr_loop_will_unroll:
                     # add unrolled loop seqs
 
                     # first add tracking data
@@ -632,7 +639,7 @@ class MaccorToBiologicMb:
                 # physical step
 
                 # last step in loop does not advance cycle, must unroll
-                if False: # is_last_step_in_loop:
+                if unroll and is_last_step_in_loop:
                     loop_will_unroll_stack[-1] = True
 
                 if get(step, "Limits.Current") or get(step, "Limits.Voltage"):
@@ -678,7 +685,7 @@ class MaccorToBiologicMb:
                 loop_will_unoll = loop_unroll_status_by_idx[idx]["will_unroll"]
                 loop = seq_loop_stack.pop()
 
-                if False: # loop_will_unoll:
+                if unroll and loop_will_unoll:
                     unrolled_loop = self._unroll_loop(
                         loop, num_loops, loop_start_seq_num, seq_num
                     )
@@ -713,6 +720,7 @@ class MaccorToBiologicMb:
                     seq_num_by_step_num,
                     step_num_goto_lower_bound,
                     end_step_num,
+                    split_step="pt1"
                 )
                 seq_loop_stack[-1].append(seq1)
                 seq2 = self._proc_step_to_seq(
@@ -721,6 +729,7 @@ class MaccorToBiologicMb:
                     seq_num_by_step_num,
                     step_num_goto_lower_bound,
                     end_step_num,
+                    split_step="pt2"
                 )
                 seq_loop_stack[-1].append(seq2)
             else:

--- a/beep/tests/test_maccor_to_biologic_mb.py
+++ b/beep/tests/test_maccor_to_biologic_mb.py
@@ -675,6 +675,6 @@ class ConversionTest(unittest.TestCase):
         pass
 
     def test_convert_diagnostic(self):
-        # convert_diagnostic_v5_multi_techniques(source_file="BioTest_000001.000")
-        with ScratchDir("."):
-            convert_diagnostic_v5_multi_techniques(source_file="diagnosticV5.000")
+        convert_diagnostic_v5_multi_techniques(source_file="BioTest_000001.000")
+        # with ScratchDir("."):
+        #     convert_diagnostic_v5_multi_techniques(source_file="diagnosticV5.000")

--- a/beep/tests/test_maccor_to_biologic_mb.py
+++ b/beep/tests/test_maccor_to_biologic_mb.py
@@ -556,11 +556,11 @@ class ConversionTest(unittest.TestCase):
             "\r\n"
             "Technique : 1\r\n"
             "Modulo Bat\r\n"
-            "Ns                  0                   1                   2                   3                   4                   5                   5                   7                   8                   9                   \r\n"
+            "Ns                  0                   1                   2                   3                   4                   5                   6                   7                   8                   9                   \r\n"
             "ctrl_type           Rest                CC                  CV                  CV                  CV                  CC                  CV                  Loop                Loop                Loop                \r\n"
             "Apply I/C           I                   I                   I                   I                   I                   I                   I                   I                   I                   I                   \r\n"
             "ctrl1_val                               1.000               3.300               3.300               3.300               142.900             4.200               100.000             100.000             100.000             \r\n"
-            "ctrl1_val_unit                          A                   A                   A                   A                   mA                  A                                                                               \r\n"
+            "ctrl1_val_unit                          A                   V                   V                   V                   mA                  V                                                                               \r\n"
             "ctrl1_val_vs                            <None>              Ref                 Ref                 Ref                 <None>              Ref                                                                             \r\n"
             "ctrl2_val                                                                                                                                                                                                                   \r\n"
             "ctrl2_val_unit                                                                                                                                                                                                              \r\n"
@@ -579,27 +579,27 @@ class ConversionTest(unittest.TestCase):
             "ctrl_Na             1                   1                   1                   1                   1                   1                   1                   1                   1                   1                   \r\n"
             "ctrl_corr           1                   1                   1                   1                   1                   1                   1                   1                   1                   1                   \r\n"
             "lim_nb              1                   1                   1                   1                   1                   1                   1                   0                   0                   0                   \r\n"
-            "lim1_type           Time                Time                I                   I                   I                   Ecell               I                   Time                Time                Time                \r\n"
+            "lim1_type           Time                Time                |I|                 |I|                 |I|                 Ecell               |I|                 Time                Time                Time                \r\n"
             "lim1_comp           >                   >                   <                   <                   <                   >                   <                   <                   <                   <                   \r\n"
             "lim1_Q              Q limit             Q limit             Q limit             Q limit             Q limit             Q limit             Q limit             Q limit             Q limit             Q limit             \r\n"
             "lim1_value          3.000               1.000               28.600              28.600              28.600              4.200               28.600              0.000               0.000               0.000               \r\n"
             "lim1_value_unit     h                   s                   mA                  mA                  mA                  V                   mA                  s                   s                   s                   \r\n"
             "lim1_action         Next sequence       Next sequence       Next sequence       Next sequence       Next sequence       Next sequence       Next sequence       Next sequence       Next sequence       Next sequence       \r\n"
-            "lim1_seq            1                   2                   3                   4                   5                   7                   7                   8                   9                   10                  \r\n"
+            "lim1_seq            1                   2                   3                   4                   5                   6                   7                   8                   9                   10                  \r\n"
             "lim2_type           Time                Time                Time                Time                Time                Time                Time                Time                Time                Time                \r\n"
             "lim2_comp           <                   <                   <                   <                   <                   <                   <                   <                   <                   <                   \r\n"
             "lim2_Q              Q limit             Q limit             Q limit             Q limit             Q limit             Q limit             Q limit             Q limit             Q limit             Q limit             \r\n"
             "lim2_value          0.000               0.000               0.000               0.000               0.000               0.000               0.000               0.000               0.000               0.000               \r\n"
             "lim2_value_unit     s                   s                   s                   s                   s                   s                   s                   s                   s                   s                   \r\n"
             "lim2_action         Next sequence       Next sequence       Next sequence       Next sequence       Next sequence       Next sequence       Next sequence       Next sequence       Next sequence       Next sequence       \r\n"
-            "lim2_seq            1                   2                   3                   4                   5                   6                   6                   8                   9                   10                  \r\n"
+            "lim2_seq            1                   2                   3                   4                   5                   6                   7                   8                   9                   10                  \r\n"
             "lim3_type           Time                Time                Time                Time                Time                Time                Time                Time                Time                Time                \r\n"
             "lim3_comp           <                   <                   <                   <                   <                   <                   <                   <                   <                   <                   \r\n"
             "lim3_Q              Q limit             Q limit             Q limit             Q limit             Q limit             Q limit             Q limit             Q limit             Q limit             Q limit             \r\n"
             "lim3_value          0.000               0.000               0.000               0.000               0.000               0.000               0.000               0.000               0.000               0.000               \r\n"
             "lim3_value_unit     s                   s                   s                   s                   s                   s                   s                   s                   s                   s                   \r\n"
             "lim3_action         Next sequence       Next sequence       Next sequence       Next sequence       Next sequence       Next sequence       Next sequence       Next sequence       Next sequence       Next sequence       \r\n"
-            "lim3_seq            1                   2                   3                   4                   5                   6                   6                   8                   9                   10                  \r\n"
+            "lim3_seq            1                   2                   3                   4                   5                   6                   7                   8                   9                   10                  \r\n"
             "rec_nb              1                   1                   2                   2                   2                   2                   2                   0                   0                   0                   \r\n"
             "rec1_type           Time                Time                Ecell               Ecell               Ecell               Ecell               Ecell               Time                Time                Time                \r\n"
             "rec1_value          30.000              10.000              1.000               1.000               1.000               1.000               1.000               10.000              10.000              10.000              \r\n"
@@ -623,7 +623,7 @@ class ConversionTest(unittest.TestCase):
         expected_lines = expected_output.split("\r\n")
 
         converter = MaccorToBiologicMb()
-        actual_output = converter.maccor_ast_to_protocol_str(maccor_ast, 20)
+        actual_output = converter.maccor_ast_to_protocol_str(maccor_ast, unroll=True, col_width=20)
         actual_lines = actual_output.split("\r\n")
 
         self.assertEqual(

--- a/beep/tests/test_maccor_to_biologic_mb.py
+++ b/beep/tests/test_maccor_to_biologic_mb.py
@@ -675,5 +675,6 @@ class ConversionTest(unittest.TestCase):
         pass
 
     def test_convert_diagnostic(self):
+        # convert_diagnostic_v5_multi_techniques(source_file="BioTest_000001.000")
         with ScratchDir("."):
             convert_diagnostic_v5_multi_techniques(source_file="diagnosticV5.000")


### PR DESCRIPTION
This PR makes loop unrolling optional so that sequence numbers can more closely match step numbers in the conversion process. It also addresses a couple of bugs related to splitting the steps with a combined control method.
- Makes unrolling an optional part of the conversion process
- Changes the sequence number `Ns` to match reality and the next sequence to match those values
- Fixes current limits to be an absolute value of the current which is more consistent with maccor behavior