### PR TITLE
Add epoch time as a column in throughput calculations

### DIFF
--- a/beep/features/featurizer_helpers.py
+++ b/beep/features/featurizer_helpers.py
@@ -17,7 +17,7 @@ from scipy.optimize import curve_fit
 from scipy.stats import skew, kurtosis
 from beep.utils import parameters_lookup
 import os
-import time
+import calendar
 
 
 # TODO: document these params
@@ -1027,7 +1027,7 @@ def get_fractional_quantity_remaining_nx(
     # Calculate the epoch time stamp at each of the measurements for later comparison
     date_time_objs = pd.to_datetime(summary_diag_cycle_type["date_time_iso"])
     date_time_float = [
-        time.mktime(t.timetuple()) if t is not pd.NaT else float("nan")
+        calendar.timegm(t.timetuple()) if t is not pd.NaT else float("nan")
         for t in date_time_objs
     ]
     summary_diag_cycle_type.drop(columns=["date_time_iso"], inplace=True)

--- a/beep/tests/test_dataset.py
+++ b/beep/tests/test_dataset.py
@@ -181,26 +181,28 @@ class TestDataset(unittest.TestCase):
         threshold_targets_df = get_threshold_targets(dataset_diagnostic_properties.data,
                                                      cycle_type="rpt_1C")
         self.assertEqual(len(threshold_targets_df), 92)
-        self.assertEqual(threshold_targets_df.columns.to_list(), ['file',
-                                                                  'seq_num',
-                                                                  'initial_regular_throughput',
-                                                                  'rpt_1Cdischarge_energy0.8_normalized_reg_throughput',
-                                                                  'rpt_1Cdischarge_energy0.8_real_reg_throughput',
-                                                                  'rpt_1Cdischarge_energy0.8_cycles']
+        print(threshold_targets_df.columns.to_list())
+        self.assertEqual(threshold_targets_df.columns.to_list(),
+                         ['file',
+                          'seq_num',
+                          'initial_regular_throughput',
+                          'rpt_1Cdischarge_energy0.8_normalized_regular_throughput',
+                          'rpt_1Cdischarge_energy0.8_cycle_index',
+                          'rpt_1Cdischarge_energy0.8_real_regular_throughput']
                          )
         self.assertEqual(threshold_targets_df[threshold_targets_df['seq_num'] == 154].round(decimals=3).to_dict("list"),
                          {
                              'file': ['PredictionDiagnostics_000154'],
                              'seq_num': [154],
                              'initial_regular_throughput': [489.31],
-                             'rpt_1Cdischarge_energy0.8_normalized_reg_throughput': [4.453],
-                             'rpt_1Cdischarge_energy0.8_real_reg_throughput': [2178.925],
-                             'rpt_1Cdischarge_energy0.8_cycles': [159.766]
+                             'rpt_1Cdischarge_energy0.8_normalized_regular_throughput': [4.453],
+                             'rpt_1Cdischarge_energy0.8_cycle_index': [159.766],
+                             'rpt_1Cdischarge_energy0.8_real_regular_throughput': [2178.925]
                           }
                          )
         threshold_targets_df = get_threshold_targets(dataset_diagnostic_properties.data,
                                                      cycle_type="rpt_1C",
                                                      extrapolate_threshold=False)
         self.assertEqual(len(threshold_targets_df), 64)
-        self.assertEqual(threshold_targets_df['rpt_1Cdischarge_energy0.8_real_reg_throughput'].round(decimals=3)
+        self.assertEqual(threshold_targets_df['rpt_1Cdischarge_energy0.8_real_regular_throughput'].round(decimals=3)
                          .median(), 2016.976)

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -214,7 +214,7 @@ class TestFeaturizer(unittest.TestCase):
             self.assertListEqual(
                 list(features_reloaded.X.iloc[2, :]),
                 [141, 0.9859837086597274, 7.885284043, 4.323121513988055,
-                 21.12108276469096, 30, 100, 'reset', 'discharge_energy'],
+                 21.12108276469096, 30, 100, 1577356063.0, 'reset', 'discharge_energy'],
             )
 
             # Workflow output
@@ -445,12 +445,12 @@ class TestFeaturizer(unittest.TestCase):
             folder = os.path.split(path)[-1]
             dumpfn(featurizer, featurizer.name)
             self.assertEqual(folder, "DiagnosticProperties")
-            self.assertEqual(featurizer.X.shape, (30, 9))
+            self.assertEqual(featurizer.X.shape, (30, 10))
             print(list(featurizer.X.iloc[2, :]))
             self.assertListEqual(
                 list(featurizer.X.iloc[2, :]),
                 [141, 0.9859837086597274, 7.885284043, 4.323121513988055,
-                 21.12108276469096, 30, 100, 'reset', 'discharge_energy']
+                 21.12108276469096, 30, 100, 1577356063.0, 'reset', 'discharge_energy']
             )
 
     @unittest.skip
@@ -527,6 +527,7 @@ class TestFeaturizerHelpers(unittest.TestCase):
         self.assertFalse(sum_diag.isnull().values.any())
         self.assertEqual(sum_diag['diagnostic_start_cycle'].iloc[0], 30)
         self.assertEqual(sum_diag['diagnostic_interval'].iloc[0], 100)
+        self.assertEqual(sum_diag['epoch_time'].iloc[0], 1576659695.0)
 
         sum_diag = featurizer_helpers.get_fractional_quantity_remaining_nx(pcycler_run,
                                                                            metric="discharge_energy",
@@ -538,6 +539,7 @@ class TestFeaturizerHelpers(unittest.TestCase):
         self.assertEqual(np.around(sum_diag["normalized_diagnostic_throughput"].iloc[15], 3), np.around(5.229, 3))
         self.assertEqual(sum_diag['diagnostic_start_cycle'].iloc[0], 30)
         self.assertEqual(sum_diag['diagnostic_interval'].iloc[0], 100)
+        self.assertEqual(sum_diag['epoch_time'].iloc[0], 1576754230.0)
 
         processed_cycler_run_path_2 = os.path.join(
             TEST_FILE_DIR, "Talos_001383_NCR18650618001_CH31_truncated_structure.json"
@@ -556,6 +558,7 @@ class TestFeaturizerHelpers(unittest.TestCase):
         self.assertEqual(np.around(sum_diag["normalized_diagnostic_throughput"].iloc[2], 3), np.around(0.385, 3))
         self.assertEqual(sum_diag['diagnostic_start_cycle'].iloc[0], 30)
         self.assertEqual(sum_diag['diagnostic_interval'].iloc[0], 200)
+        self.assertEqual(sum_diag['epoch_time'].iloc[0], 1598174928.0)
 
     def test_generate_dQdV_peak_fits(self):
         processed_cycler_run_path = os.path.join(

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -214,7 +214,7 @@ class TestFeaturizer(unittest.TestCase):
             self.assertListEqual(
                 list(features_reloaded.X.iloc[2, :]),
                 [141, 0.9859837086597274, 7.885284043, 4.323121513988055,
-                 21.12108276469096, 30, 100, 1577356063.0, 'reset', 'discharge_energy'],
+                 21.12108276469096, 30, 100, 1577338063, 'reset', 'discharge_energy'],
             )
 
             # Workflow output
@@ -450,7 +450,7 @@ class TestFeaturizer(unittest.TestCase):
             self.assertListEqual(
                 list(featurizer.X.iloc[2, :]),
                 [141, 0.9859837086597274, 7.885284043, 4.323121513988055,
-                 21.12108276469096, 30, 100, 1577356063.0, 'reset', 'discharge_energy']
+                 21.12108276469096, 30, 100, 1577338063, 'reset', 'discharge_energy']
             )
 
     @unittest.skip
@@ -527,7 +527,7 @@ class TestFeaturizerHelpers(unittest.TestCase):
         self.assertFalse(sum_diag.isnull().values.any())
         self.assertEqual(sum_diag['diagnostic_start_cycle'].iloc[0], 30)
         self.assertEqual(sum_diag['diagnostic_interval'].iloc[0], 100)
-        self.assertEqual(sum_diag['epoch_time'].iloc[0], 1576659695.0)
+        self.assertEqual(sum_diag['epoch_time'].iloc[0], 1576641695)
 
         sum_diag = featurizer_helpers.get_fractional_quantity_remaining_nx(pcycler_run,
                                                                            metric="discharge_energy",
@@ -539,7 +539,7 @@ class TestFeaturizerHelpers(unittest.TestCase):
         self.assertEqual(np.around(sum_diag["normalized_diagnostic_throughput"].iloc[15], 3), np.around(5.229, 3))
         self.assertEqual(sum_diag['diagnostic_start_cycle'].iloc[0], 30)
         self.assertEqual(sum_diag['diagnostic_interval'].iloc[0], 100)
-        self.assertEqual(sum_diag['epoch_time'].iloc[0], 1576754230.0)
+        self.assertEqual(sum_diag['epoch_time'].iloc[0], 1576736230)
 
         processed_cycler_run_path_2 = os.path.join(
             TEST_FILE_DIR, "Talos_001383_NCR18650618001_CH31_truncated_structure.json"
@@ -558,7 +558,7 @@ class TestFeaturizerHelpers(unittest.TestCase):
         self.assertEqual(np.around(sum_diag["normalized_diagnostic_throughput"].iloc[2], 3), np.around(0.385, 3))
         self.assertEqual(sum_diag['diagnostic_start_cycle'].iloc[0], 30)
         self.assertEqual(sum_diag['diagnostic_interval'].iloc[0], 200)
-        self.assertEqual(sum_diag['epoch_time'].iloc[0], 1598174928.0)
+        self.assertEqual(sum_diag['epoch_time'].iloc[0], 1598156928)
 
     def test_generate_dQdV_peak_fits(self):
         processed_cycler_run_path = os.path.join(


### PR DESCRIPTION
This PR adds a column "epoch_time" that is the timestamp in seconds of the cycle metric that is being calculated. This should make it possible to use epoch time in the threshold calculations