### PR TITLE
Add files for test time extraction

### DIFF
--- a/beep/features/TestTimeDemo.ipynb
+++ b/beep/features/TestTimeDemo.ipynb
@@ -1,0 +1,441 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "232da4bd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "env: BEEP_ENV=dev\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from monty.serialization import loadfn, dumpfn\n",
+    "from glob import glob\n",
+    "from datetime import datetime\n",
+    "%env BEEP_ENV=dev\n",
+    "from beep import structure, run_model, featurize\n",
+    "from beep.featurize import (\n",
+    "    RPTdQdVFeatures,\n",
+    "    HPPCResistanceVoltageFeatures,\n",
+    "    DiagnosticSummaryStats,\n",
+    "    HPPCRelaxationFeatures,\n",
+    "    DiagnosticProperties\n",
+    ")\n",
+    "\n",
+    "# import yaml\n",
+    "from beep.dataset import BeepDataset\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib import cm\n",
+    "import matplotlib\n",
+    "import seaborn as sns\n",
+    "import os\n",
+    "# from throughput_dev_tri import get_threshold_targets\n",
+    "import pickle\n",
+    "from scipy.interpolate import interp1d\n",
+    "from scipy import optimize\n",
+    "from scipy.optimize import differential_evolution\n",
+    "# from dtw import *\n",
+    "from IntracellAnalysis import *\n",
+    "from test_time_helpers import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ab4435d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.set_option('display.max_columns', None)\n",
+    "pd.set_option('display.max_rows', 40)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "31733336",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Setting Path for Loading Data in Loop\n",
+    "project_list = [\"PreDiag\", \"PredictionDiagnostics\"]\n",
+    "FEATURIZER_CLASSES = [RPTdQdVFeatures, HPPCResistanceVoltageFeatures, DiagnosticSummaryStats, DiagnosticProperties]\n",
+    "\n",
+    "raw_path = \"/home/ec2-user/SageMaker/efs-readonly/raw/maccor\"\n",
+    "processed_path = \"/home/ec2-user/SageMaker/efs-readonly/structure/\"\n",
+    "featurized_path = \"/home/ec2-user/SageMaker/efs-readonly/features/\"\n",
+    "predictions_path = \"/home/ec2-user/SageMaker/efs-readonly/features/\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e81fc41e",
+   "metadata": {},
+   "source": [
+    "## Function call to load in test times of all cells past threshold with specified cycling parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b706df5c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "protocol_params = pd.DataFrame({'charge_constant_current_1' : 0.5,\n",
+    "                                'charge_constant_current_2' : 0.5,\n",
+    "                                'discharge_constant_current' : 0.2,\n",
+    "                                'charge_cutoff_voltage' : 4.1,\n",
+    "                                'discharge_cutoff_voltage' : 2.7},index=[0])\n",
+    "test_time_df, test_time_stats_df = get_protocol_test_time_stats(protocol_params=protocol_params)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "4bd4f8c4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>test_time_to_eol</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>174</th>\n",
+       "      <td>1.419632e+07</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>177</th>\n",
+       "      <td>1.190680e+07</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>256</th>\n",
+       "      <td>1.192188e+07</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>359</th>\n",
+       "      <td>1.187580e+07</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>360</th>\n",
+       "      <td>1.188340e+07</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>361</th>\n",
+       "      <td>1.179358e+07</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     test_time_to_eol\n",
+       "174      1.419632e+07\n",
+       "177      1.190680e+07\n",
+       "256      1.192188e+07\n",
+       "359      1.187580e+07\n",
+       "360      1.188340e+07\n",
+       "361      1.179358e+07"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_time_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "a1a83f57",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>mean</th>\n",
+       "      <th>std</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1.226296e+07</td>\n",
+       "      <td>865577.677997</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           mean            std\n",
+       "0  1.226296e+07  865577.677997"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_time_stats_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4161b409",
+   "metadata": {},
+   "source": [
+    "## Functional call for test time based on provided list of seq_num"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "049422ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_time_df = get_test_time_df_from_seq_num_list(seq_num_list=[174,177],\n",
+    "                                       nominal_capacity=4.83,\n",
+    "                                       threshold=0.8,\n",
+    "                                       cycle_type='rpt_0.2C',\n",
+    "                                       project_list=[\"PreDiag\", \"PredictionDiagnostics\"],\n",
+    "                                       processed_path=\"/home/ec2-user/SageMaker/efs-readonly/structure/\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "f474f9a9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>test_time_to_eol</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>174</th>\n",
+       "      <td>1.419632e+07</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>177</th>\n",
+       "      <td>1.190680e+07</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     test_time_to_eol\n",
+       "174      1.419632e+07\n",
+       "177      1.190680e+07"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_time_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c33d1912",
+   "metadata": {},
+   "source": [
+    "## Function call for cell that is unfinished"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "6428a098",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "protocol_params = pd.DataFrame({'charge_constant_current_1' : 0.2,\n",
+    "                                'charge_constant_current_2' : 0.2,\n",
+    "                                'discharge_constant_current' : 0.2,\n",
+    "                                'charge_cutoff_voltage' : 4.1,\n",
+    "                                'discharge_cutoff_voltage' : 3.7},index=[0])\n",
+    "unfinished_test_time_df = get_unfinished_test_time_from_seq_num_list(seq_num_list=[246],\n",
+    "                                         nominal_capacity=4.83,\n",
+    "                                         threshold=0.8,\n",
+    "                                         cycle_type='rpt_0.2C'\n",
+    "                                         )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "52a7decc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>test_time_to_date</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>246</th>\n",
+       "      <td>260.600066</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     test_time_to_date\n",
+       "246         260.600066"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "unfinished_test_time_df/60/60/24"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 181,
+   "id": "a9da73f5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    117.072237\n",
+       "Name: mean, dtype: float64"
+      ]
+     },
+     "execution_count": 181,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_time_df/60/60/24\n",
+    "test_time_stats_df['mean']/60/60/24"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "conda_beep-env",
+   "language": "python",
+   "name": "conda_beep-env"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/beep/features/test_time_helpers.py
+++ b/beep/features/test_time_helpers.py
@@ -1,0 +1,178 @@
+import json
+import numpy as np
+import pandas as pd
+from monty.serialization import loadfn, dumpfn
+from glob import glob
+from datetime import datetime
+from beep import structure, run_model, featurize
+from beep.featurize import (
+    RPTdQdVFeatures,
+    HPPCResistanceVoltageFeatures,
+    DiagnosticSummaryStats,
+    HPPCRelaxationFeatures,
+    DiagnosticProperties
+)
+
+# import yaml
+from beep.dataset import BeepDataset
+import matplotlib.pyplot as plt
+from matplotlib import cm
+import matplotlib
+import seaborn as sns
+import os
+# from throughput_dev_tri import get_threshold_targets
+import pickle
+from scipy.interpolate import interp1d
+from scipy import optimize
+from scipy.optimize import differential_evolution
+# from dtw import *
+from IntracellAnalysis import *
+# import ternary
+
+def get_protocol_test_time_stats(protocol_params=pd.DataFrame({'charge_constant_current_1' : 0.2},index=[0]),
+                                 project_list=["PreDiag", "PredictionDiagnostics"],
+                                 processed_path="/home/ec2-user/SageMaker/efs-readonly/structure/",
+                                 protocol_reference_file='PreDiag_parameters_20210302.csv',
+                                 nominal_capacity=4.83,
+                                 threshold=0.8,
+                                 cycle_type='rpt_0.2C'):
+    """
+    This function retrieves test time information and computes summary statistics on that test time information.
+    Test time information is extracted for cell's matching the protocol parameters provided in protocol_params
+    and also have reached the fractional capacity defined by threshold for the diagnostic given by cycle_type.
+    
+    Inputs:
+    protocol_params: DataFrame containing columns for the cycling parameters of interest to group upon. Only one row.
+    project_list: list of project names to allow in search for repeated protocols.
+    processed_path: path of procesed cell data.
+    protocol_reference_file: csv file containing columns for cycling protocol information.
+    
+    Outputs:
+    test_time_df: DataFrame containing  test time in seconds with seq_num as index.
+    test_time_stats_df: DataFrame with one row containing summary statistics (mean, std) for the cells in test_time_df.
+    """
+    
+    seq_num_list = get_seq_num_list_from_protocol_params(protocol_params=protocol_params,
+                                     protocol_reference_file=protocol_reference_file,
+                                     )
+    test_time_df = get_test_time_df_from_seq_num_list(seq_num_list=seq_num_list,
+                                                  nominal_capacity=nominal_capacity,
+                                                  threshold=threshold,
+                                                  cycle_type=cycle_type
+                                                  )
+    test_time_stats_df = pd.DataFrame({'mean':np.nanmean(test_time_df['test_time_to_eol']),
+                                       'std':np.nanstd(test_time_df['test_time_to_eol'])},
+                                       index=[0])
+    return test_time_df, test_time_stats_df
+
+def get_seq_num_list_from_protocol_params(protocol_params=pd.DataFrame(),
+                                          protocol_reference_file='PreDiag_parameters_20210302.csv'):
+    """
+    This function collects a list of seq_num which have cycling protocols with parameters matching those provdided in protocol_params.
+    
+    Inputs:
+    protocol_params: DataFrame containing columns for the cycling parameters of interest to group upon. Only one row.
+    protocol_reference_file: csv file containing columns for cycling protocol information.
+    
+    Outputs:
+    seq_num_list: list of seq_num that have cycling protocols with parameters matching those provdided in protocol_params.
+    """    
+    
+    protocol_reference = pd.read_csv('PreDiag_parameters_20210302.csv').set_index('seq_num')
+    seq_num_list = protocol_reference.groupby(by=protocol_params.columns.to_list()).get_group(tuple(protocol_params.values.ravel())).index.to_list()
+    return seq_num_list
+
+def get_test_time_df_from_seq_num_list(seq_num_list=[],
+                                       nominal_capacity=4.83,
+                                       threshold=0.8,
+                                       cycle_type='rpt_0.2C',
+                                       project_list=["PreDiag", "PredictionDiagnostics"],
+                                       processed_path="/home/ec2-user/SageMaker/efs-readonly/structure/"):
+    """
+    This function extracts the test time endured until a provided threshold on fractional capacity is achieved,
+    for a set of cells provided in seq_num_list.
+    
+    Inputs:
+    seq_num_list: list of seq_num that have cycling protocols with parameters matching those provdided in protocol_params.
+    nominal_capacity: nominal capacity of cell.
+    threshold: fractional metric threshold for when the test time should be extracted.
+    cycle_type: diagnostic type for which the threshold will be applied.
+    project_list: list of project names to allow in search for repeated protocols.
+    processed_path: path of procesed cell data.
+    
+    Outputs:
+    test_time_df: DataFrame containing test time in seconds with seq_num as index.
+    """    
+    
+    threshold_capacity = nominal_capacity*threshold
+    
+    test_time_list = []
+    seq_num_list_finished = []
+    for seq_num in seq_num_list:
+        processed_run_list = [os.path.join(processed_path, f) 
+                      for project_name in project_list 
+                      for f in os.listdir(processed_path) 
+                      if (os.path.isfile(os.path.join(processed_path, f)) and f.startswith(project_name)) and 'p2' not in f and project_name]
+        
+        assert [x for x in processed_run_list if int(x[-25:-22]) == seq_num], "unable to process cell "+str(seq_num)
+        processed_run_for_seq_num = ([x for x in processed_run_list if int(x[-25:-22]) == seq_num])[0]
+        cell_struct = loadfn(processed_run_for_seq_num)
+        
+        below_threshold_rows = cell_struct.diagnostic_summary.loc[
+            (cell_struct.diagnostic_summary['discharge_capacity'] < threshold_capacity) & (cell_struct.diagnostic_summary.cycle_type == cycle_type)
+                                                            ]
+        if (len(below_threshold_rows) > 0):
+            cycle_index_eol = cell_struct.diagnostic_summary.loc[
+                (cell_struct.diagnostic_summary['discharge_capacity'] < threshold_capacity) & (cell_struct.diagnostic_summary.cycle_type == cycle_type)
+                                                            ].iloc[0,:].cycle_index
+        else:
+            print('cell with seq_num '+str(seq_num)+' is in the designated protocol group, but has not reached the threshold.')
+            continue
+        test_time = np.nanmax(cell_struct.diagnostic_data.loc[
+            cell_struct.diagnostic_data.cycle_index == cycle_index_eol]['test_time']
+                              ) - np.nanmin(cell_struct.diagnostic_data['test_time'])
+        test_time_list.append(test_time)
+        seq_num_list_finished.append(seq_num)
+    test_time_df = pd.DataFrame(test_time_list,index=seq_num_list_finished,columns=['test_time_to_eol'])
+    
+    return test_time_df
+
+def get_unfinished_test_time_from_seq_num_list(seq_num_list=[],
+                                         nominal_capacity=4.83,
+                                         threshold=0.8,
+                                         cycle_type='rpt_0.2C',
+                                         project_list=["PreDiag", "PredictionDiagnostics"],
+                                         processed_path="/home/ec2-user/SageMaker/efs-readonly/structure/"):
+    """
+    This function computes the total test time that has so far been endured for the cells provided in seq_num_list.
+    
+    Inputs:
+    seq_num_list: list of seq_num that have cycling protocols with parameters matching those provdided in protocol_params.
+    nominal_capacity: nominal capacity of cell.
+    threshold: fractional metric threshold for when the test time should be extracted.
+    cycle_type: diagnostic type for which the threshold will be applied.
+    project_list: list of project names to allow in search for repeated protocols.
+    processed_path: path of procesed cell data.
+    
+    Outputs:
+    unfinished_test_time_df: DataFrame containing test time in seconds with seq_num as index.
+    """    
+    
+    threshold_capacity = nominal_capacity*threshold
+    
+    test_time_list = []
+    seq_num_list_finished = []
+    for seq_num in seq_num_list:
+        processed_run_list = [os.path.join(processed_path, f) 
+                      for project_name in project_list 
+                      for f in os.listdir(processed_path) 
+                      if (os.path.isfile(os.path.join(processed_path, f)) and f.startswith(project_name)) and 'p2' not in f and project_name]
+        
+        assert [x for x in processed_run_list if int(x[-25:-22]) == seq_num], "unable to process cell "+str(seq_num)
+        processed_run_for_seq_num = ([x for x in processed_run_list if int(x[-25:-22]) == seq_num])[0]
+        cell_struct = loadfn(processed_run_for_seq_num)
+        test_time_to_date = np.nanmax(cell_struct.diagnostic_data['test_time']) - np.nanmin(cell_struct.diagnostic_data['test_time'])
+        test_time_list.append(test_time_to_date)
+        
+    unfinished_test_time_df = pd.DataFrame(test_time_list,index=seq_num_list,columns=['test_time_to_date'])
+    return unfinished_test_time_df


### PR DESCRIPTION
These files provide functions and a demo notebook that enable extraction of the total test time until a provided threshold or overall test time.
There are included methods for gathering the test time for all cells with the same cycling protocols.
These methods are intended to aid in experiment planning.