### PR TITLE
Working version of new interpolation

### DIFF
--- a/beep/tests/test_structure_base.py
+++ b/beep/tests/test_structure_base.py
@@ -279,7 +279,6 @@ class TestBEEPDatapath(unittest.TestCase):
         interval = discharge.iloc[measurement_index: measurement_index + 2]
         interval = interval.drop(columns=["date_time_iso"])  # Drop non-numeric column
 
-
         # Test interpolation with a by-hand calculation of slope
         diff = np.diff(interval, axis=0)
         pred = interval.iloc[[0]] + diff * (
@@ -555,6 +554,19 @@ class TestBEEPDatapath(unittest.TestCase):
         plt.plot(hppc_dischg1.test_time, hppc_dischg1.voltage)
         plt.savefig(os.path.join(TEST_FILE_DIR, "hppc_discharge_pulse_1.png"))
         self.assertEqual(len(hppc_dischg1), 176)
+
+        hppc_dischg2 = diag_interpolated[
+            (diag_interpolated.cycle_index == 37)
+            & (diag_interpolated.step_type == 6)
+            # & (diag_interpolated.step_index_counter == 3)
+            & ~pd.isnull(diag_interpolated.current)
+            ]
+        print(hppc_dischg2.step_type.unique())
+        self.assertAlmostEqual(hppc_dischg2.voltage.min(), hppc_dischg2.voltage.max(), 3)
+        plt.figure()
+        plt.plot(hppc_dischg2.test_time, hppc_dischg2.current)
+        plt.savefig(os.path.join(TEST_FILE_DIR, "hppc_cv.png"))
+        self.assertEqual(len(hppc_dischg2), 1000)
 
         # processed_cycler_run = cycler_run.to_processed_cycler_run()
         md.autostructure()

--- a/beep/tests/test_structure_cyclerpaths.py
+++ b/beep/tests/test_structure_cyclerpaths.py
@@ -31,8 +31,6 @@ from beep.structure.battery_archive import BatteryArchiveDatapath
 from beep.tests.constants import TEST_FILE_DIR
 
 
-
-
 class TestArbinDatapath(unittest.TestCase):
     """
     Tests specific to Arbin cyclers.
@@ -52,7 +50,6 @@ class TestArbinDatapath(unittest.TestCase):
         )
 
         os.environ["BEEP_PROCESSING_DIR"] = TEST_FILE_DIR
-
 
     # from RCRT.test_serialization
     def test_serialization(self):
@@ -82,9 +79,11 @@ class TestArbinDatapath(unittest.TestCase):
         # print(diag['parameter_set'])
         self.assertEqual(diag['parameter_set'], 'NCR18650-618')
         diag_interp = rcycler_run.interpolate_diagnostic_cycles(diag, resolution=1000, v_resolution=0.0005)
-        # print(diag_interp[diag_interp.cycle_index == 1].charge_capacity.median())
-        self.assertEqual(np.around(diag_interp[diag_interp.cycle_index == 1].charge_capacity.median(), 3),
-                         np.around(3.428818545441403, 3))
+        self.assertAlmostEqual(diag_interp[(diag_interp.cycle_index == 1) &
+                                           (diag_interp.step_index == 5)].charge_capacity.max(),
+                               3.39608899, 3)
+        self.assertAlmostEqual(diag_interp[(diag_interp.cycle_type == "hppc")].charge_capacity.max(),
+                               3.4919972, 3)
 
 
 class TestMaccorDatapath(unittest.TestCase):

--- a/beep/utils/waveform.py
+++ b/beep/utils/waveform.py
@@ -106,8 +106,8 @@ class RapidChargeWave:
         assert np.all(np.diff(mesh_points)) > 0
         current_smooth, time_smooth, current_multistep, time_multistep = \
             self.get_input_currents_both_to_final_soc(charging_c_rates, mesh_points)
-        end_time_smooth = np.int(np.round(np.max(time_smooth), 0))
-        end_time_multistep = np.int(np.round(np.max(time_multistep), 0))
+        end_time_smooth = int(np.round(np.max(time_smooth), 0))
+        end_time_multistep = int(np.round(np.max(time_multistep), 0))
         assert end_time_smooth == end_time_multistep
 
         time_uniform = np.arange(0, end_time_smooth, 1)


### PR DESCRIPTION
This PR changes the interpolation of the diagnostic cycles so that cv steps are interpolated on time instead of voltage. This is important so that enough points are included for feature extraction.