### PR TITLE
CV summary stats

### DIFF
--- a/beep/conversion_schemas/arbin_conversion.yaml
+++ b/beep/conversion_schemas/arbin_conversion.yaml
@@ -38,7 +38,7 @@ data_columns:
   temperature: temperature
 data_types:
   data_point: 'int32'
-  test_time: 'float32'
+  test_time: 'float64'
   datetime: 'float32'
   step_time: 'float32'
   step_index: 'int16'

--- a/beep/conversion_schemas/maccor_conversion.yaml
+++ b/beep/conversion_schemas/maccor_conversion.yaml
@@ -51,7 +51,7 @@ data_types:
   rec#: 'int32'
   cyc#: 'int32'
   step: 'int16'
-  test (sec): 'float32'
+  test (sec): 'float64'
   step (sec): 'float32'
   amp-hr: 'float64'
   watt-hr: 'float64'

--- a/beep/conversion_schemas/neware_conversion.yaml
+++ b/beep/conversion_schemas/neware_conversion.yaml
@@ -26,7 +26,7 @@ data_columns:
   Temperature(C): temperature
 data_types:
   Record ID: 'int32'
-  test_time: 'float32'
+  test_time: 'float64'
   Time(h:min:s.ms): 'float32'
   Step ID: 'int16'
   Cycle ID: 'int32'

--- a/beep/conversion_schemas/structured_dtypes.yaml
+++ b/beep/conversion_schemas/structured_dtypes.yaml
@@ -28,6 +28,8 @@ summary:
   charge_duration: 'float32'
   time_temperature_integrated: 'float64'
   paused: 'int32'
+  CV_time: 'float32'
+  CV_current: 'float32'
 
 diagnostic_summary:
   discharge_capacity: 'float64'
@@ -42,6 +44,8 @@ diagnostic_summary:
   coulombic_efficiency: 'float64'
   paused: 'int32'
   cycle_type: 'category'
+  CV_time: 'float32'
+  CV_current: 'float32'
 
 diagnostic_interpolated:
   voltage: 'float32'

--- a/beep/structure/base.py
+++ b/beep/structure/base.py
@@ -1414,13 +1414,16 @@ def get_max_paused_over_threshold(group, paused_threshold=3600):
     return max_paused_duration
 
 
-def get_CV_segment_from_charge(charge):
+def get_CV_segment_from_charge(charge, dt_tol=1, dVdt_tol=5e-5, dIdt_tol=1e-4):
     """
     Extracts the constant voltage segment from charge. Works for both CCCV or
     CC steps followed by a CV step.
 
     Args:
         charge (pd.DataFrame): charge dataframe for a single cycle
+        dt_tol (float) : dt tolernace (minimum) for identifying CV
+        dVdt_tol (float) : dVdt tolerance (maximum) for identifying CV
+        dIdt_tol (float) : dVdt tolerance (minimum) for identifying CV 
 
     Returns:
         (pd.DataFrame): dataframe containing the CV segment
@@ -1431,9 +1434,9 @@ def get_CV_segment_from_charge(charge):
     dV = np.diff(charge.voltage)
     dt = np.diff(charge.test_time)
 
-    # Find the first index where dt>1 and abs(dV/dt)<tol and abs(dI/dt)>tol
+    # Find the first index where the CV segment begins
     i = 0
-    while i < len(dV) and not (dt[i] > 1 and abs(dV[i]/dt[i]) < 5.e-5 and abs(dI[i]/dt[i]) > 1.e-4):
+    while i < len(dV) and not (dt[i] > dt_tol and abs(dV[i]/dt[i]) < dVdt_tol and abs(dI[i]/dt[i]) > dIdt_tol):
         i = i+1
 
     # Filter for CV phase

--- a/beep/structure/battery_archive.py
+++ b/beep/structure/battery_archive.py
@@ -41,7 +41,7 @@ class BatteryArchiveDatapath(BEEPDatapath):
 
     # Mapping of data types for BEEP columns
     DATA_TYPES = {
-        "test_time": "float32",
+        "test_time": "float64",
         "cycle_index": "int32",
         "current": "float32",
         "voltage": "float32",

--- a/beep/tests/test_structure_base.py
+++ b/beep/tests/test_structure_base.py
@@ -334,6 +334,8 @@ class TestBEEPDatapath(unittest.TestCase):
                     "charge_energy",
                     "discharge_energy",
                     "energy_efficiency",
+                    "CV_time",
+                    "CV_current",
                 },
                 set(summary_diag.columns),
             )
@@ -341,6 +343,8 @@ class TestBEEPDatapath(unittest.TestCase):
         self.assertEqual(summary_diag["cycle_index"].tolist(), list(range(0, 13)))
         self.assertEqual(len(summary_diag.index), len(summary_diag["date_time_iso"]))
         self.assertEqual(summary_diag["paused"].max(), 0)
+        self.assertEqual(summary_diag["CV_time"][1], np.float32(160111.796875))
+        self.assertEqual(summary_diag["CV_current"][1], np.float32(0.4699016))
         self.run_dtypes_check(summary_diag)
 
         # incorporates test_get_energy and get_charge_throughput
@@ -417,6 +421,8 @@ class TestBEEPDatapath(unittest.TestCase):
     def test_summarize_diagnostic(self):
         diag_summary = self.datapath_diag.summarize_diagnostic(self.diagnostic_available)
         self.assertEqual(diag_summary["paused"].max(), 0)
+        self.assertEqual(diag_summary["CV_time"][0], np.float32(125502.578125))
+        self.assertEqual(diag_summary["CV_current"][0], np.float32(2.3499656))
 
     # based on RCRT.test_determine_paused
     def test_paused_intervals(self):

--- a/docs_src/writing_your_own.md
+++ b/docs_src/writing_your_own.md
@@ -133,7 +133,7 @@ class MyCyclerDatapath(BEEPDatapath):
 
     # Mapping of data types for BEEP columns
     DATA_TYPES = {
-        "test_time": "float32",
+        "test_time": "float64",
         "cycle_index": "int32",
         "current": "float32",
         "voltage": "float32",


### PR DESCRIPTION
Adds cv_time and cv_current as summary stats to the regular cycles and diagnostic cycles. cv_time is the length of the CV segment of charge (useful for CV with current limit), and cv_current is the current at the end of the segment (useful for CV with time limit).

Also changes test_time from float32 to float64 in order to handle large times without decimal truncation.