### PR TITLE
Change versions of boto and update tests

### DIFF
--- a/.github/workflows/beep-test.yml
+++ b/.github/workflows/beep-test.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           MPLBACKEND: "Agg"
           BEEP_ENV: "dev"
-          BIG_FILE_TESTS: "True"
+          BEEP_BIG_TESTS: "True"
         run: |
           pytest beep --color=yes --cov=beep --cov-config=.coveragerc --cov-report html:coverage_reports
       - name: Coveralls

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -787,8 +787,14 @@ class TestRawToFeatures(unittest.TestCase):
             import pprint
             pprint.pprint(reloaded)
 
-            result_list = ['success'] * 5
+            result_list = ['success'] * 7
             self.assertEqual(reloaded['result_list'], result_list)
             res_df = loadfn(reloaded['file_list'][0])
-
-            self.assertAlmostEqual(res_df.X['r_c_0s_00'].iloc[0], -0.098951, 5)
+            self.assertEqual(res_df.class_feature_name, "HPPCResistanceVoltageFeatures")
+            print(res_df.X)
+            self.assertAlmostEqual(res_df.X['r_c_0s_00'].iloc[0], -0.159771397, 5)
+            self.assertAlmostEqual(res_df.X['r_c_0s_10'].iloc[0], -0.143679, 5)
+            self.assertAlmostEqual(res_df.X['r_c_0s_20'].iloc[0], -0.146345, 5)
+            self.assertAlmostEqual(res_df.X['D_6'].iloc[0], -0.167919, 5)
+            self.assertAlmostEqual(res_df.X['D_7'].iloc[0], 0.094136, 5)
+            self.assertAlmostEqual(res_df.X['D_8'].iloc[0], 0.172496, 5)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@ scikit-learn==0.24.2
 pandas==1.3.0
 cerberus==1.3.4
 tqdm==4.61.2
-boto3==1.17.109
-botocore==1.20.109
+boto3==1.18.1
+botocore==1.21.1
 pytz==2021.1
 watchtower==1.0.6
 docopt==0.6.2


### PR DESCRIPTION
This PR updates the versions of boto to resolve some dependency issues. It also updates the featurization test from raw data. It appears that the switch of test_time and test (sec) from float32 to float64 changes the resistance values in the feature.