### PR TITLE
Extend intracell threshold

### DIFF
--- a/beep/features/intracell_analysis.py
+++ b/beep/features/intracell_analysis.py
@@ -151,7 +151,7 @@ class IntracellAnalysis:
     # IA constants
     UPPER_VOLTAGE = 4.2
     LOWER_VOLTAGE = 2.7
-    THRESHOLD = 4.84 * 0.8
+    THRESHOLD = 4.84 * 0.7
 
     def __init__(self,
                  pe_pristine_file,

--- a/beep/tests/test_intracell_analysis.py
+++ b/beep/tests/test_intracell_analysis.py
@@ -416,7 +416,7 @@ class IntracellFeaturesTest(unittest.TestCase):
 
             # Modify pcycler_run to be invalid
             mask = pcycler_run.diagnostic_summary.cycle_type == "rpt_0.2C"
-            pcycler_run.diagnostic_summary.loc[mask, "discharge_capacity"] = 3.5
+            pcycler_run.diagnostic_summary.loc[mask, "discharge_capacity"] = 3.35
 
             featurizer = IntracellFeatures.from_run(
                 run_path, os.getcwd(), pcycler_run, params_dict=params_dict


### PR DESCRIPTION
Change the threshold for conducting the intracell analysis from 0.8 to 0.7, so that we may be able to include at least one cycle that goes below 0.8. This way, we can interpolate the final states at 0.8 rather than extrapolate. Before this change, we would be guaranteed to not include the diagnostic with fractional metric below 0.8.