### PR TITLE
Decrease the tolerance for more accurate extraction of CV from CCCV

### DIFF
--- a/beep/structure/base.py
+++ b/beep/structure/base.py
@@ -1426,7 +1426,7 @@ def get_max_paused_over_threshold(group, paused_threshold=3600):
     return max_paused_duration
 
 
-def get_CV_segment_from_charge(charge, dt_tol=1, dVdt_tol=5e-5, dIdt_tol=1e-4):
+def get_CV_segment_from_charge(charge, dt_tol=1, dVdt_tol=1e-5, dIdt_tol=1e-4):
     """
     Extracts the constant voltage segment from charge. Works for both CCCV or
     CC steps followed by a CV step.


### PR DESCRIPTION
CV was occasionally not being extracted correctly for some cycles (see for example 'PreDiag_000447'). Part of the CC segment is sometimes included as CV. Decreasing the tolerance settings seems to fix the issue.