### PR TITLE
test for goto end bug

### DIFF
--- a/beep/tests/test_files/goto_end_example.000
+++ b/beep/tests/test_files/goto_end_example.000
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?maccor-application progid="Maccor Procedure File"?>
+<MaccorTestProcedure>
+  <header>
+    <BuildTestVersion>
+      <major>1</major>
+      <minor>5</minor>
+      <release>7006</release>
+      <build>32043</build>
+    </BuildTestVersion>
+    <FileFormatVersion>
+      <BTVersion>11</BTVersion>
+    </FileFormatVersion>
+    <ProcDesc>
+      <desc></desc>
+    </ProcDesc>
+  </header>
+  <ProcSteps>
+    <TestStep>
+      <StepType>  Rest  </StepType>
+      <StepMode>        </StepMode>
+      <StepValue></StepValue>
+      <Limits/>
+      <Ends>
+        <EndEntry>
+          <EndType>StepTime</EndType>
+          <SpecialType> </SpecialType>
+          <Oper> = </Oper>
+          <Step>003</Step>
+          <Value>03:00:00</Value>
+        </EndEntry>
+      </Ends>
+      <Reports>
+        <ReportEntry>
+          <ReportType>StepTime</ReportType>
+          <Value>00:00:30</Value>
+        </ReportEntry>
+      </Reports>
+      <Range>4</Range>
+      <Option1>N</Option1>
+      <Option2>N</Option2>
+      <Option3>N</Option3>
+      <StepNote></StepNote>
+    </TestStep>
+     <TestStep>
+      <StepType> Charge </StepType>
+      <StepMode>Current </StepMode>
+      <StepValue>1.0</StepValue>
+      <Limits/>
+      <Ends>
+        <EndEntry>
+          <EndType>StepTime</EndType>
+          <SpecialType> </SpecialType>
+          <Oper> = </Oper>
+          <Step>003</Step>
+          <Value>00:00:01</Value>
+        </EndEntry>
+        <EndEntry>
+          <EndType>Current </EndType>
+          <SpecialType> </SpecialType>
+          <Oper>&gt;= </Oper>
+          <Step>003</Step>
+          <Value>1.0</Value>
+        </EndEntry>
+        <EndEntry>
+          <EndType>Current </EndType>
+          <SpecialType> </SpecialType>
+          <Oper>&lt;= </Oper>
+          <Step>003</Step>
+          <Value>0.1</Value>
+        </EndEntry>
+      </Ends>
+      <Reports>
+        <ReportEntry>
+          <ReportType>StepTime</ReportType>
+          <Value>::.01</Value>
+        </ReportEntry>
+      </Reports>
+      <Range>A</Range>
+      <Option1>N</Option1>
+      <Option2>N</Option2>
+      <Option3>N</Option3>
+      <StepNote>never runs</StepNote>
+    </TestStep>
+    <TestStep>
+      <StepType>  End   </StepType>
+      <StepMode>        </StepMode>
+      <StepValue></StepValue>
+      <Limits/>
+      <Ends/>
+      <Reports/>
+      <Range></Range>
+      <Option1></Option1>
+      <Option2></Option2>
+      <Option3></Option3>
+      <StepNote></StepNote>
+    </TestStep>
+  </ProcSteps>
+</MaccorTestProcedure>

--- a/beep/tests/test_maccor_to_biologic_mb.py
+++ b/beep/tests/test_maccor_to_biologic_mb.py
@@ -14,6 +14,7 @@
 """Unit tests for maccor protcol files to biologic modulo bat protcol files"""
 
 import os
+from typing import OrderedDict
 import unittest
 import xmltodict
 import copy
@@ -509,6 +510,25 @@ class ConversionTest(unittest.TestCase):
             cycle_transition_rules.__repr__(),
             parsed_cycle_transition_rules.__repr__(),
         )
+
+    def test_convert_protocol_with_goto_end_step(self):
+        path = os.path.join(TEST_FILE_DIR, "goto_end_example.000")
+        converter = MaccorToBiologicMb()
+        ast = converter.load_maccor_ast(path)
+        test_steps = get(ast, "MaccorTestProcedure.ProcSteps.TestStep")
+        assert isinstance(test_steps, list)
+
+        first_step = test_steps[0]
+        first_step_goto = int(get(first_step, "Ends.EndEntry.Step"))
+        assert first_step_goto == len(test_steps)
+        assert first_step_goto not in [1, 2]
+
+        converted_fp, rule_fps = converter.convert(path, TEST_FILE_DIR, "to_delete")
+        os.remove(converted_fp)
+        for rule_fp in rule_fps:
+            os.remove(rule_fp)
+
+
 
 step_with_bounds_template = (
     "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"


### PR DESCRIPTION
This PR adds a test for[ this pull request ](https://github.com/TRI-AMDD/beep/pull/403) where the converter was crashing when the protocol contained a step that could GOTO the end step, and that step did not immediately precede the end step.

This PR includes a minimal example protocol: 2 physical steps, 1 end step, where the first step GOTOs the end step and a test that converts it.

