### PR TITLE
Fix matplotlib requirement install issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ boto3==1.18.48
 botocore==1.21.48
 pytz==2021.1
 watchtower==1.0.6
-docopt==0.6.2
 msgpack-python==0.5.6
 python-dateutil==2.8.2
 ruamel.yaml==0.17.16
@@ -18,3 +17,4 @@ tables==3.6.1
 pydash==5.0.2
 lmfit==1.0.2
 click==8.0.1
+matplotlib>=3.3.4


### PR DESCRIPTION
Package would not install/run as-is due to matplotlib needing to be imported in some modules, and it not being listed under requirements.

Also, removed docopt as it is not needed.