### PR TITLE
Change suffix separator to better align with previous usage

### DIFF
--- a/beep/cmd.py
+++ b/beep/cmd.py
@@ -67,8 +67,8 @@ from beep.protocol.generate_protocol import ProtocolException
 
 CLICK_FILE = click.Path(file_okay=True, dir_okay=False, writable=False, readable=True)
 CLICK_DIR = click.Path(file_okay=False, dir_okay=True, writable=True, readable=True)
-STRUCTURED_SUFFIX = "-structured"
-FEATURIZED_SUFFIX = "-featurized"
+STRUCTURED_SUFFIX = "_structured"
+FEATURIZED_SUFFIX = "_featurized"
 
 
 class ContextPersister:


### PR DESCRIPTION
This PR changes the separator for the suffix to underscore instead of hyphen to better match the previous file naming pattern.
