### PR TITLE
CV capacity summary statistic

### DIFF
--- a/beep/conversion_schemas/structured_dtypes.yaml
+++ b/beep/conversion_schemas/structured_dtypes.yaml
@@ -30,6 +30,7 @@ summary:
   paused: 'int32'
   CV_time: 'float32'
   CV_current: 'float32'
+  CV_capacity: 'float32'
 
 diagnostic_summary:
   discharge_capacity: 'float64'
@@ -46,6 +47,7 @@ diagnostic_summary:
   cycle_type: 'category'
   CV_time: 'float32'
   CV_current: 'float32'
+  CV_capacity: 'float32'
 
 diagnostic_interpolated:
   voltage: 'float32'

--- a/beep/structure/base.py
+++ b/beep/structure/base.py
@@ -1530,7 +1530,7 @@ def get_CV_segment_from_charge(charge, dt_tol=1, dVdt_tol=1e-5, dIdt_tol=1e-4):
 
     # Find the first index where the CV segment begins
     i = 0
-    while i < len(dV) and not (dt[i] > dt_tol and abs(dV[i]/dt[i]) < dVdt_tol and abs(dI[i]/dt[i]) > dIdt_tol):
+    while i < len(dV) and (dt[i] < dt_tol or abs(dV[i]/dt[i]) > dVdt_tol or abs(dI[i]/dt[i]) < dIdt_tol):
         i = i+1
 
     # Filter for CV phase

--- a/beep/structure/tests/test_base.py
+++ b/beep/structure/tests/test_base.py
@@ -345,6 +345,7 @@ class TestBEEPDatapath(unittest.TestCase):
                     "energy_efficiency",
                     "CV_time",
                     "CV_current",
+                    "CV_capacity"
                 },
                 set(summary_diag.columns),
             )
@@ -354,6 +355,7 @@ class TestBEEPDatapath(unittest.TestCase):
         self.assertEqual(summary_diag["paused"].max(), 0)
         self.assertEqual(summary_diag["CV_time"][1], np.float32(160111.796875))
         self.assertEqual(summary_diag["CV_current"][1], np.float32(0.4699016))
+        self.assertEqual(summary_diag["CV_capacity"][1], np.float32(94.090355))
         self.run_dtypes_check(summary_diag)
 
         # incorporates test_get_energy and get_charge_throughput
@@ -432,6 +434,7 @@ class TestBEEPDatapath(unittest.TestCase):
         self.assertEqual(diag_summary["paused"].max(), 0)
         self.assertEqual(diag_summary["CV_time"][0], np.float32(125502.578125))
         self.assertEqual(diag_summary["CV_current"][0], np.float32(2.3499656))
+        self.assertEqual(diag_summary["CV_capacity"][0], np.float32(84.70442))
 
     # based on RCRT.test_determine_paused
     def test_paused_intervals(self):


### PR DESCRIPTION
This adds a CV capacity summary statistic for both regular and diagnostic cycles, which is distinct from the CV time and current stats I added previously. I included a regression test.

After merging I would appreciate a re-run of structuring on AWS for PreDiag and PredictionDiagnostics data sets.

