### PR TITLE
Reset default saving option for structured_data: to not include raw_data 

### DIFF
--- a/beep/structure/base.py
+++ b/beep/structure/base.py
@@ -316,7 +316,7 @@ class BEEPDatapath(abc.ABC, MSONable):
 
         return cls.from_dict(d)
 
-    def to_json_file(self, filename, omit_raw=False):
+    def to_json_file(self, filename, omit_raw=True):
         """Save a BEEPDatapath to disk as a json.
 
         .json.gz files are supported.


### PR DESCRIPTION
Current structured_data saved in json.gz includes both raw data and structured data. 
Now:  reset default json file of structured data, so that structured_data is included, raw_data is not