### PR TITLE
v2022.5.2.14 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,9 @@
-
+v2022.5.2.14
+------------
+* Update beep contribution guideline
+* Remove raw data from default structured files
+* Adds a CV capacity summary stat.
+* Drop testing for python 3.7 due to updating packages
 
 v2022.2.7.14
 ------------

--- a/beep/__init__.py
+++ b/beep/__init__.py
@@ -21,7 +21,7 @@ except (ImportError, ModuleNotFoundError):
 # Versioning.  The python code version is frequently tagged
 # with a commit hash from the repo, which is supplied via
 # an environment variable by the integration build procedure
-__version__ = "2022.2.7.14"
+__version__ = "2022.5.2.14"
 VERSION_TAG = os.environ.get("BEEP_VERSION_TAG")
 if VERSION_TAG is not None:
     __version__ = "-".join([__version__, VERSION_TAG])

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ description = "beep is a python package supporting Battery Estimation and Early 
 
 setup(name="beep",
       url="https://github.com/TRI-AMDD/beep",
-      version="2022.2.7.14",
+      version="2022.5.2.14",
       description=description,
       long_description=long_description,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
* Update beep contribution guideline
* Remove raw data from default structured files
* Adds a CV capacity summary stat.
* Drop testing for python 3.7 due to updating packages