### PR TITLE
Bugfix novonix ingestion for cycles with no charge step

### DIFF
--- a/beep/structure/base.py
+++ b/beep/structure/base.py
@@ -612,10 +612,12 @@ class BEEPDatapath(abc.ABC, MSONable):
         if not exclude_cycles:
             exclude_cycles = []
 
-        if not desc:
+        if not desc and axis == "voltage":
             desc = \
                 f"Interpolating {step_type} ({v_range[0]} - {v_range[1]})V " \
                 f"({resolution} points)"
+        elif not desc:
+            desc = f"Interpolating {step_type} on axis {axis} ({resolution} points)"
 
         incl_columns = [
             "test_time",

--- a/beep/structure/tests/test_cyclerpaths.py
+++ b/beep/structure/tests/test_cyclerpaths.py
@@ -557,6 +557,20 @@ class TestNovonixDatapath(unittest.TestCase):
             else:
                 self.assertTrue((step_df["step_type"] == "charge").all())
 
+        # Ensure no cycles have all nan dchg cap or chg cap
+        for i, cyc_df in rd.groupby("cycle_index"):
+            df_dchg = cyc_df[cyc_df["step_type"] == "discharge"]
+            if not df_dchg.empty:
+                for convention in ("capacity", "energy"):
+                    print(f"Checking cycle {i} for discharge {convention}.")
+                    self.assertFalse(df_dchg[f"discharge_{convention}"].isna().all())
+
+        # Explicitly ensure there is discharge capacity for cycle 4
+        cyc4 = rd[rd["cycle_index"] == 4]
+        self.assertFalse(cyc4["discharge_capacity"].isna().all())
+        self.assertAlmostEqual(cyc4["discharge_capacity"].iloc[0], 0.0, places=5)
+        self.assertAlmostEqual(cyc4["discharge_capacity"].iloc[127], 0.014467, places=5)
+
         is_valid, reason = dp.validate()
         self.assertTrue(is_valid)
 


### PR DESCRIPTION
- Previously, novonix ingestion failed silently (nans for all values of dchg cap and energy) on cycles where there are no charge steps, as the caps/engs could not be converted to montonically increasing since there was no max value from a charge step
- Now, explicitly accounts for these cycles with no charge step by setting the maximums from the highest raw `capacity` value within the cycle. Now the convention for these cycles is `discharge_capacity` = `max_discharge_capacity_within_this_cycle` - `capacity` (and similarly for energy). The other cycles are unchanged
- Also includes tests specifically for this case now in `test_cyclerpaths.TestNovonixDatapath.test_file_long` by looking explicitly at cycle 4.
- Also includes a warning when this extra conversion is needed. It looks like this:
    - `2022-08-16 13:13:05 WARNING  No charge steps found in cycles [4]! Using highest capacity reading to determine convention.`
- Also fixes a bug where interpolation axis was not shown if axis != `voltage`

For reference, cycle 4 of the long test file now looks like this once ingested:

<img width="1211" alt="image" src="https://user-images.githubusercontent.com/19936203/184977546-962300fd-3b68-44a4-bdda-e92a42feefa6.png">

And slinear interpolated (resolution=100)/structured

<img width="1042" alt="image" src="https://user-images.githubusercontent.com/19936203/184983989-291c879a-facd-4a81-94d0-de88af4241fd.png">

